### PR TITLE
Revamp header and login layout

### DIFF
--- a/FindTradie.Web/Pages/Home.razor
+++ b/FindTradie.Web/Pages/Home.razor
@@ -9,74 +9,52 @@
 <div class="emergency-banner">Emergency Services Available</div>
 
 <div class="hero-section">
-    <div class="container">
-        <div class="row align-items-center">
-            <div class="col-lg-6">
-                <h1 class="hero-title">Find Trusted Local Tradies</h1>
-                <p class="hero-subtitle">Connect with verified, available professionals in your area.</p>
-                <div class="search-card mt-4">
-                    <h3 class="mb-3">What service do you need?</h3>
-                    <div class="search-form">
-                        <div class="form-floating mb-3 input-wrapper location-input">
-                            <input @bind="SearchLocation" class="form-control" id="location" placeholder="" />
-                            <label for="location">Your location</label>
-                        </div>
-                        <div class="form-floating mb-3 input-wrapper service-input">
-                            <select @bind="SelectedCategory" class="form-select service-select" id="service">
-                                <option value="" disabled selected>Select a service</option>
-                                @foreach (var category in ServiceCategories)
-                                {
-                                    <option value="@((int)category.Key)">@category.Value</option>
-                                }
-                            </select>
-                            <label for="service">Service needed</label>
-                        </div>
-                        <div class="form-floating mb-3 input-wrapper urgency-input">
-                            <select @bind="SelectedUrgency" class="form-select" id="urgency">
-                                <option value="false">Within a week</option>
-                                <option value="true">Available now / Emergency</option>
-                            </select>
-                            <label for="urgency">When do you need this?</label>
-                        </div>
-                        <button class="btn btn-primary btn-find-tradies btn-lg w-100 @(IsSearching ? "btn-loading" : string.Empty)" @onclick="SearchTradies" disabled="@IsSearching">
-                            <span>Find Tradies <i class="fa-solid fa-arrow-right ms-2"></i></span>
-                        </button>
-                        <button class="btn btn-outline-secondary btn-lg w-100 mt-3" @onclick="NavigateToPostJob">Post a Job</button>
+    <div class="hero-content">
+        <div class="hero-left">
+            <h1 class="hero-title">Find Trusted Local Tradies</h1>
+            <p class="hero-subtitle">Connect with verified, available professionals in your area.</p>
+            <div class="search-card mt-4">
+                <h3 class="mb-3">What service do you need?</h3>
+                <div class="search-form">
+                    <div class="form-floating mb-3 input-wrapper location-input">
+                        <input @bind="SearchLocation" class="form-control" id="location" placeholder="" />
+                        <label for="location">Your location</label>
                     </div>
+                    <div class="form-floating mb-3 input-wrapper service-input">
+                        <select @bind="SelectedCategory" class="form-select service-select" id="service">
+                            <option value="" disabled selected>Select a service</option>
+                            @foreach (var category in ServiceCategories)
+                            {
+                                <option value="@((int)category.Key)">@category.Value</option>
+                            }
+                        </select>
+                        <label for="service">Service needed</label>
+                    </div>
+                    <div class="form-floating mb-3 input-wrapper urgency-input">
+                        <select @bind="SelectedUrgency" class="form-select" id="urgency">
+                            <option value="false">Within a week</option>
+                            <option value="true">Available now / Emergency</option>
+                        </select>
+                        <label for="urgency">When do you need this?</label>
+                    </div>
+                    <button class="btn btn-primary btn-find-tradies btn-lg w-100 @(IsSearching ? \"btn-loading\" : string.Empty)" @onclick="SearchTradies" disabled="@IsSearching">
+                        <span>Find Tradies <i class="fa-solid fa-arrow-right ms-2"></i></span>
+                    </button>
+                    <button class="btn btn-outline-secondary btn-lg w-100 mt-3" @onclick="NavigateToPostJob">Post a Job</button>
                 </div>
             </div>
-            <div class="col-lg-6 mt-5 mt-lg-0 text-center hero-right">
-                <div class="feature-badges">
-                    <div class="badge verified mb-3"><i class="fa-solid fa-circle-check me-2"></i>Verified Tradies</div>
-                    <div class="badge insured mb-3"><i class="fa-solid fa-shield-halved me-2"></i>Insured</div>
-                    <div class="badge quotes"><i class="fa-solid fa-comments-dollar me-2"></i>Free Quotes</div>
-                </div>
-                <div class="hero-image mt-4">
-                    <img src="images/happy-tradies.svg" alt="Happy customers" class="img-fluid hero-illustration" />
-                </div>
+            <div class="trust-badges">
+                <div class="trust-badge"><i class="fa-solid fa-circle-check"></i><span>Verified Tradies</span></div>
+                <div class="trust-badge"><i class="fa-solid fa-shield-halved"></i><span>Insured</span></div>
+                <div class="trust-badge"><i class="fa-solid fa-comments-dollar"></i><span>Free Quotes</span></div>
             </div>
+        </div>
+        <div class="hero-right">
+            <img src="images/happy-tradies.svg" alt="Happy customers" class="img-fluid hero-illustration" />
         </div>
     </div>
 </div>
 
-<div class="trust-indicators">
-    <div class="trust-badge">
-        <i class="fas fa-shield-alt"></i>
-        <span>100% Verified</span>
-    </div>
-    <div class="trust-badge">
-        <i class="fas fa-lock"></i>
-        <span>Secure Payments</span>
-    </div>
-    <div class="trust-badge">
-        <i class="fas fa-clipboard-check"></i>
-        <span>Licensed &amp; Insured</span>
-    </div>
-    <div class="trust-badge">
-        <i class="fas fa-star"></i>
-        <span>Quality Guarantee</span>
-    </div>
-</div>
 
 <div class="services bg-white">
     <div class="container">

--- a/FindTradie.Web/Pages/Login.razor
+++ b/FindTradie.Web/Pages/Login.razor
@@ -8,14 +8,14 @@
 
 <PageTitle>Login - FindTradie</PageTitle>
 
-<div class="auth-container">
-    <div class="auth-card">
+<div class="login-page">
+    <div class="login-card">
         <div class="auth-header">
             <h2>Welcome Back</h2>
             <p>Sign in to your FindTradie account</p>
         </div>
 
-        <div class="auth-form">
+        <div class="login-form">
             @if (!string.IsNullOrEmpty(ErrorMessage))
             {
                 <div class="alert alert-danger">@ErrorMessage</div>
@@ -23,15 +23,15 @@
 
             <div class="form-group mb-3">
                 <label for="email">Email Address</label>
-                <input @bind="Email" type="email" class="form-control" id="email" placeholder="Enter your email" />
+                <input @bind="Email" type="email" id="email" placeholder="Enter your email" />
             </div>
 
             <div class="form-group mb-3">
                 <label for="password">Password</label>
-                <input @bind="Password" type="password" class="form-control" id="password" placeholder="Enter your password" />
+                <input @bind="Password" type="password" id="password" placeholder="Enter your password" />
             </div>
 
-            <button class="btn btn-primary w-100 mb-3" @onclick="LoginAsync" disabled="@IsLoading">
+            <button @onclick="LoginAsync" disabled="@IsLoading">
                 @if (IsLoading)
                 {
                     <span class="spinner-border spinner-border-sm me-2"></span>

--- a/FindTradie.Web/Shared/NavMenu.razor
+++ b/FindTradie.Web/Shared/NavMenu.razor
@@ -1,79 +1,60 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @inject AuthenticationStateProvider AuthStateProvider
 
-<nav class="navbar navbar-light fixed-top top-header">
-    <div class="container header-nav">
-        <a class="navbar-brand" href="">
-            <i class="fa-solid fa-hammer me-2"></i>FindTradie
-        </a>
-        <button class="navbar-toggler" @onclick="ToggleNavMenu">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="navbar-collapse collapse @(collapseNavMenu ? string.Empty : "show")">
-            <ul class="navbar-nav ms-auto align-items-lg-center nav-links">
-                <li class="nav-item">
-                    <NavLink class="nav-link" href="" Match="NavLinkMatch.All">Home</NavLink>
-                </li>
-                <AuthorizeView>
-                    <Authorized>
-                        <li class="nav-item">
-                            <NavLink class="nav-link" href="dashboard">Dashboard</NavLink>
-                        </li>
-                        <li class="nav-item">
-                            <NavLink class="nav-link" href="jobs">My Jobs</NavLink>
-                        </li>
-                        @if (IsTradie)
-                        {
-                            <li class="nav-item">
-                                <NavLink class="nav-link" href="tradie/profile">My Profile</NavLink>
-                            </li>
-                            <li class="nav-item">
-                                <NavLink class="nav-link" href="tradie/jobs">Browse Jobs</NavLink>
-                            </li>
-                        }
-                        else
-                        {
-                            <li class="nav-item">
-                                <NavLink class="nav-link" href="post-job">Post a Job</NavLink>
-                            </li>
-                            <li class="nav-item">
-                                <NavLink class="nav-link" href="find-tradies">Find Tradies</NavLink>
-                            </li>
-                        }
-                        <li class="nav-item ms-lg-3">
-                            <LoginDisplay />
-                        </li>
-                    </Authorized>
-                    <NotAuthorized>
-                        <li class="nav-item">
-                            <NavLink class="nav-link" href="find-tradies">Find Tradies</NavLink>
-                        </li>
-                        <li class="nav-item ms-lg-3">
-                            <LoginDisplay />
-                        </li>
-                    </NotAuthorized>
-                </AuthorizeView>
-            </ul>
+<header class="main-header">
+    <div class="header-container">
+        <div class="header-left">
+            <a href="/" class="brand">
+                <span class="brand-icon">🔨</span>
+                <span class="brand-name">FindTradie</span>
+            </a>
+            <nav class="desktop-nav">
+                <NavLink href="/" class="nav-link" Match="NavLinkMatch.All">Home</NavLink>
+                <NavLink href="/find-tradies" class="nav-link">Find Tradies</NavLink>
+                <NavLink href="/how-it-works" class="nav-link">How It Works</NavLink>
+                <NavLink href="/post-job" class="nav-link">Post a Job</NavLink>
+            </nav>
+        </div>
+        <div class="header-right">
+            <AuthorizeView>
+                <Authorized>
+                    <LoginDisplay />
+                </Authorized>
+                <NotAuthorized>
+                    <a href="/register" class="btn btn-outline">Register</a>
+                    <a href="/login" class="btn btn-primary">Log in</a>
+                </NotAuthorized>
+            </AuthorizeView>
+            <button class="mobile-menu-toggle" @onclick="ToggleNavMenu">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
         </div>
     </div>
-</nav>
+    <nav class="mobile-nav @(collapseNavMenu ? string.Empty : "active")">
+        <NavLink href="/" class="nav-link" Match="NavLinkMatch.All" @onclick="ToggleNavMenu">Home</NavLink>
+        <NavLink href="/find-tradies" class="nav-link" @onclick="ToggleNavMenu">Find Tradies</NavLink>
+        <NavLink href="/how-it-works" class="nav-link" @onclick="ToggleNavMenu">How It Works</NavLink>
+        <NavLink href="/post-job" class="nav-link" @onclick="ToggleNavMenu">Post a Job</NavLink>
+        <AuthorizeView>
+            <Authorized>
+                <LoginDisplay />
+            </Authorized>
+            <NotAuthorized>
+                <a href="/register" class="nav-link" @onclick="ToggleNavMenu">Register</a>
+                <a href="/login" class="nav-link" @onclick="ToggleNavMenu">Log in</a>
+            </NotAuthorized>
+        </AuthorizeView>
+    </nav>
+</header>
 
 @code {
     private bool collapseNavMenu = true;
-    private bool IsTradie = false;
-
-    protected override async Task OnInitializedAsync()
-    {
-        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
-        if (authState.User.Identity?.IsAuthenticated == true)
-        {
-            var userTypeClaim = authState.User.FindFirst("UserType")?.Value;
-            IsTradie = userTypeClaim == "2";
-        }
-    }
 
     private void ToggleNavMenu()
     {
         collapseNavMenu = !collapseNavMenu;
     }
 }
+

--- a/FindTradie.Web/wwwroot/css/site.css
+++ b/FindTradie.Web/wwwroot/css/site.css
@@ -20,6 +20,7 @@ body {
     font-family: var(--font-body);
     color: var(--text-primary);
     background: #ffffff;
+    padding-top: 70px;
 }
 
 h1, h2, h3 {
@@ -72,47 +73,136 @@ main {
     padding: 0 !important;
 }
 
-/* Header Navigation */
-.top-header {
+/* Header */
+.main-header {
     position: fixed;
     top: 0;
-    width: 100%;
-    background: rgba(255, 255, 255, 0.95);
-    backdrop-filter: blur(10px);
+    left: 0;
+    right: 0;
+    background: white;
     box-shadow: 0 2px 10px rgba(0,0,0,0.1);
     z-index: 1000;
-    padding: 1rem 2rem;
+    height: 70px;
 }
 
-.header-nav {
+.header-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+    height: 100%;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    max-width: 1200px;
-    margin: 0 auto;
 }
 
-.nav-links {
+.header-left {
     display: flex;
-    gap: 1rem;
     align-items: center;
+    gap: 40px;
 }
 
-.btn-register, .btn-login {
+.brand {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    text-decoration: none;
+    font-size: 24px;
+    font-weight: bold;
+    color: #1a202c;
+}
+
+.brand-icon {
+    font-size: 28px;
+}
+
+.desktop-nav {
+    display: flex;
+    gap: 30px;
+}
+
+.desktop-nav .nav-link {
+    color: #4a5568;
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.3s;
+    padding: 5px 10px;
+}
+
+.desktop-nav .nav-link:hover {
+    color: #3182ce;
+}
+
+.header-right {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+.header-right .btn {
     padding: 0.5rem 1.5rem;
     border-radius: 8px;
     font-weight: 500;
 }
 
-.btn-register {
+.header-right .btn-outline {
     background: white;
     color: #3b82f6;
     border: 2px solid #3b82f6;
 }
 
-.btn-login {
-    background: #3b82f6;
+.header-right .btn-primary {
+    background: #3182ce;
     color: white;
+}
+
+.mobile-menu-toggle {
+    display: none;
+    background: none;
+    border: none;
+    cursor: pointer;
+}
+
+.mobile-menu-toggle span {
+    display: block;
+    width: 25px;
+    height: 3px;
+    background: #1a202c;
+    margin: 5px 0;
+    transition: 0.3s;
+}
+
+.mobile-nav {
+    display: none;
+    flex-direction: column;
+    gap: 20px;
+    background: white;
+    position: absolute;
+    top: 70px;
+    left: 0;
+    right: 0;
+    padding: 20px;
+    box-shadow: 0 10px 20px rgba(0,0,0,0.1);
+}
+
+.mobile-nav.active {
+    display: flex;
+}
+
+.mobile-nav .nav-link {
+    color: #4a5568;
+    text-decoration: none;
+    font-weight: 500;
+    padding: 10px 0;
+}
+
+@media (max-width: 768px) {
+    .desktop-nav {
+        display: none;
+    }
+
+    .mobile-menu-toggle {
+        display: block;
+    }
 }
 
 /* Emergency banner */
@@ -125,21 +215,30 @@ main {
 }
 
 /* Hero Section */
-/* Hero Section */
 .hero-section {
-    background:
-        linear-gradient(135deg, rgba(99, 102, 241, 0.9), rgba(139, 92, 246, 0.9)),
-        url('../images/hero-pattern.svg');
-    position: relative;
-    overflow: hidden;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     padding: 60px 0;
+    min-height: 500px;
+    display: flex;
+    align-items: center;
+}
+
+.hero-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 60px;
+    align-items: center;
+}
+
+.hero-left {
     color: white;
-    background-size: cover;
 }
 
 .hero-right {
     display: flex;
-    align-items: center;
     justify-content: center;
 }
 
@@ -148,20 +247,21 @@ main {
     filter: drop-shadow(0 20px 40px rgba(0,0,0,0.2));
 }
 
-.trust-indicators {
+.trust-badges {
     display: flex;
-    gap: 2rem;
-    margin: 2rem 0;
-    justify-content: center;
-    flex-wrap: wrap;
+    gap: 20px;
+    margin-top: 30px;
 }
 
 .trust-badge {
+    background: rgba(255,255,255,0.2);
+    padding: 10px 20px;
+    border-radius: 8px;
+    backdrop-filter: blur(10px);
+    color: white;
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    color: var(--text-primary);
-    opacity: 0.9;
+    gap: 10px;
 }
 
 .hero-title {
@@ -337,31 +437,6 @@ main {
 .btn-lg {
     padding: 1rem 2rem;
     font-size: 1.125rem;
-}
-
-/* Feature Badges */
-.hero-image {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 400px;
-}
-
-.feature-badges {
-    display: grid;
-    gap: 1rem;
-}
-
-.feature-badges .badge {
-    background: rgba(255, 255, 255, 0.2);
-    backdrop-filter: blur(10px);
-    padding: 1rem 1.5rem;
-    border-radius: 12px;
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    color: white;
-    border: 1px solid rgba(255, 255, 255, 0.3);
 }
 
 /* Service Cards */
@@ -908,4 +983,43 @@ h1, h2, h3, h4, h5, h6, p, span, div, label {
     .col-lg-6 {
         flex: 0 0 100%;
     }
+}
+
+/* Login Page */
+.login-page {
+    min-height: calc(100vh - 70px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
+.login-card {
+    background: white;
+    padding: 40px;
+    border-radius: 12px;
+    box-shadow: 0 20px 40px rgba(0,0,0,0.1);
+    width: 100%;
+    max-width: 400px;
+}
+
+.login-form input {
+    width: 100%;
+    padding: 12px;
+    margin-bottom: 15px;
+    border: 2px solid #e2e8f0;
+    border-radius: 8px;
+    font-size: 16px;
+}
+
+.login-form button {
+    width: 100%;
+    padding: 14px;
+    background: #3182ce;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
 }

--- a/FindTradie.Web/wwwroot/js/site.js
+++ b/FindTradie.Web/wwwroot/js/site.js
@@ -46,6 +46,13 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         backToTop.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
     }
+
+    const mobileToggle = document.querySelector('.mobile-menu-toggle');
+    const mobileMenu = document.querySelector('.mobile-nav');
+    mobileToggle?.addEventListener('click', () => {
+        mobileMenu?.classList.toggle('active');
+        mobileToggle.classList.toggle('active');
+    });
 });
 
 window.showToast = (message, type) => {


### PR DESCRIPTION
## Summary
- Implement fixed header with visible navigation links, auth actions, and responsive mobile menu
- Restructure hero section and remove floating badges for cleaner landing experience
- Rebuild login page with centered card and constrained width

## Testing
- ⚠️ `dotnet build` *(missing dotnet CLI and unable to install via apt)*

------
https://chatgpt.com/codex/tasks/task_e_689f037a2f54832ea0cd918629f5cc82