### PR TITLE
Improve hero search form styling and trust badges

### DIFF
--- a/FindTradie.Web/Pages/Home.razor
+++ b/FindTradie.Web/Pages/Home.razor
@@ -14,53 +14,64 @@
             <h1 class="hero-title">Find Trusted Local Tradies</h1>
             <p class="hero-subtitle">Connect with verified, available professionals in your area.</p>
             <div class="search-card mt-4">
-                <h3 class="mb-3">What service do you need?</h3>
-                <div class="search-form">
-                    <!-- Location (input) -->
-                    <div class="form-floating mb-3 field-with-icon">
-                        <i class="fa-solid fa-location-dot form-icon"></i>
-                        <input @bind="SearchLocation" class="form-control" id="location" placeholder=" " />
-                        <label for="location">Your location</label>
+                <h3>What service do you need?</h3>
+                <form class="search-form">
+                    <!-- Location field -->
+                    <div class="form-group">
+                        <label class="form-label">
+                            <span class="label-icon"><i class="fa-solid fa-location-dot"></i></span>
+                            Your location
+                        </label>
+                        <input @bind="SearchLocation" type="text" class="form-control" placeholder="Enter suburb or postcode" />
                     </div>
 
-                    <!-- Service (select) -->
-                    <div class="form-floating mb-3 field-with-icon">
-                        <i class="fa-solid fa-screwdriver-wrench form-icon"></i>
-                        <select @bind="SelectedCategory" class="form-select" id="service">
-                            <option value="" disabled selected>Select a service</option>
+                    <!-- Service selection -->
+                    <div class="form-group">
+                        <label class="form-label">
+                            <span class="label-icon"><i class="fa-solid fa-screwdriver-wrench"></i></span>
+                            Service needed
+                        </label>
+                        <select @bind="SelectedCategory" class="form-select">
+                            <option value="">Select a service</option>
                             @foreach (var c in ServiceCategories)
                             {
                                 <option value="@((int)c.Key)">@c.Value</option>
                             }
                         </select>
-                        <label for="service">Service needed</label>
                     </div>
 
-                    <!-- Urgency (select) -->
-                    <div class="form-floating mb-3 field-with-icon">
-                        <i class="fa-solid fa-clock form-icon"></i>
-                        <select @bind="SelectedUrgency" class="form-select" id="urgency">
-                            <option value="false">Within a week</option>
-                            <option value="true">Available now / Emergency</option>
+                    <!-- Urgency selection -->
+                    <div class="form-group">
+                        <label class="form-label">
+                            <span class="label-icon"><i class="fa-solid fa-clock"></i></span>
+                            When do you need this?
+                        </label>
+                        <select @bind="SelectedUrgency" class="form-select">
+                            <option value="week">Within a week</option>
+                            <option value="month">Within a month</option>
+                            <option value="urgent">Urgent (Within 24 hours)</option>
+                            <option value="emergency">Emergency (ASAP)</option>
                         </select>
-                        <label for="urgency">When do you need this?</label>
                     </div>
 
-
-
-                    <button class="btn btn-primary btn-find-tradies btn-lg w-100 @(IsSearching ? "btn-loading" : string.Empty)"
-                            @onclick="SearchTradies"
-                            disabled="@IsSearching">
-                        <span>Find Tradies <i class="fa-solid fa-arrow-right ms-2"></i></span>
+                    <!-- Action buttons -->
+                    <button type="button" class="btn btn-primary btn-lg @(IsSearching ? \"btn-loading\" : string.Empty)" @onclick="SearchTradies" disabled="@IsSearching">
+                        Find Tradies
+                        <span class="btn-arrow">→</span>
                     </button>
 
-                    <button class="btn btn-outline-secondary btn-lg w-100 mt-3" @onclick="NavigateToPostJob">Post a Job</button>
+                    <div class="divider">
+                        <span>or</span>
+                    </div>
+
+                    <button type="button" class="btn btn-outline btn-lg" @onclick="NavigateToPostJob">Post a Job</button>
+                </form>
+
+                <div class="trust-badges">
+                    <div class="trust-badge"><i class="fa-solid fa-circle-check trust-badge-icon"></i><span>Verified Tradies</span></div>
+                    <div class="trust-badge"><i class="fa-solid fa-shield-halved trust-badge-icon"></i><span>Insured</span></div>
+                    <div class="trust-badge"><i class="fa-solid fa-comments-dollar trust-badge-icon"></i><span>Free Quotes</span></div>
                 </div>
-            </div>
-            <div class="trust-badges">
-                <div class="trust-badge"><i class="fa-solid fa-circle-check"></i><span>Verified Tradies</span></div>
-                <div class="trust-badge"><i class="fa-solid fa-shield-halved"></i><span>Insured</span></div>
-                <div class="trust-badge"><i class="fa-solid fa-comments-dollar"></i><span>Free Quotes</span></div>
             </div>
         </div>
     </div>
@@ -411,7 +422,7 @@
 @code {
     private string SearchLocation = string.Empty;
     private string SelectedCategory = string.Empty;
-    private string SelectedUrgency = "false";
+    private string SelectedUrgency = "week";
     private bool IsSearching = false;
     private List<TradieProfileSummaryDto>? SearchResults;
 
@@ -459,7 +470,7 @@
                 RadiusKm: 25,
                 Categories: !string.IsNullOrEmpty(SelectedCategory) ?
                     new List<ServiceCategory> { (ServiceCategory)int.Parse(SelectedCategory) } : null,
-                AvailableNow: bool.Parse(SelectedUrgency)
+                AvailableNow: SelectedUrgency == "urgent" || SelectedUrgency == "emergency"
             );
 
             var response = await TradieService.SearchTradiesAsync(searchRequest);

--- a/FindTradie.Web/wwwroot/css/site.css
+++ b/FindTradie.Web/wwwroot/css/site.css
@@ -247,21 +247,27 @@ main {
     filter: drop-shadow(0 20px 40px rgba(0,0,0,0.2));
 }
 
-.trust-badges {
+
+/* Search card trust badges */
+.search-card .trust-badges {
     display: flex;
-    gap: 20px;
-    margin-top: 30px;
+    justify-content: space-around;
+    padding-top: 20px;
+    margin-top: 20px;
+    border-top: 1px solid #e5e7eb;
 }
 
-.trust-badge {
-    background: rgba(255,255,255,0.2);
-    padding: 10px 20px;
-    border-radius: 8px;
-    backdrop-filter: blur(10px);
-    color: white;
+.search-card .trust-badge {
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: 8px;
+    font-size: 14px;
+    color: #6b7280;
+}
+
+.search-card .trust-badge-icon {
+    color: #10b981;
+    font-size: 18px;
 }
 
 .hero-title {
@@ -281,10 +287,11 @@ main {
 /* Search Card */
 .search-card {
     background: white;
-    padding: 2.5rem;
+    padding: 2rem 2rem 1.5rem;
     border-radius: 16px;
-    box-shadow: 0 20px 60px rgba(0,0,0,0.15);
+    box-shadow: 0 20px 40px rgba(0,0,0,0.15);
     color: #2d3748;
+    position: relative;
 }
 
 .search-card h3 {
@@ -295,40 +302,58 @@ main {
 }
 
 /* Form Styles */
+
 .form-group {
-    margin-bottom: 1.5rem;
+    margin-bottom: 20px;
 }
 
-.form-group label {
+.form-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    color: #374151;
+    text-align: left;
+}
+
+.label-icon {
+    display: inline-block;
+    margin-right: 6px;
+    font-size: 16px;
+}
+
+.form-helper {
     display: block;
-    margin-bottom: 0.5rem;
-    font-weight: 500;
-    color: #4a5568;
-    font-size: 0.95rem;
+    margin-top: 4px;
+    font-size: 13px;
+    color: #6b7280;
+    text-align: left;
 }
 
 .form-control,
 .form-select {
     width: 100%;
-    padding: 1rem 1rem 1rem 3rem;
+    padding: 14px 16px;
+    font-size: 16px;
     border: 2px solid #e5e7eb;
     border-radius: 8px;
-    font-size: 1rem;
-    transition: all 0.3s;
     background: white;
+    transition: all 0.3s;
 }
 
 .form-control:focus,
 .form-select:focus {
     outline: none;
-    border-color: #3182ce;
-    box-shadow: 0 0 0 3px rgba(49, 130, 206, 0.1);
-    transform: translateY(-2px);
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 
-.service-select option {
-    padding: 10px;
-    line-height: 1.5;
+.form-control::placeholder,
+.form-select::placeholder {
+    color: #9ca3af;
+    font-size: 15px;
 }
 
 .form-floating label {
@@ -371,25 +396,63 @@ main {
 
 /* Buttons */
 .btn {
-    padding: 0.75rem 1.5rem;
+    width: 100%;
+    padding: 16px 24px;
     border-radius: 8px;
+    font-size: 16px;
     font-weight: 600;
-    transition: all 0.3s;
-    border: none;
     cursor: pointer;
-    display: inline-block;
-    text-align: center;
+    transition: all 0.3s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    border: none;
 }
 
 .btn-primary {
-    background: #3182ce;
+    background: linear-gradient(135deg, #3b82f6, #2563eb);
     color: white;
+    border: none;
 }
 
 .btn-primary:hover {
-    background: #2563eb;
     transform: translateY(-2px);
-    box-shadow: 0 10px 20px rgba(49, 130, 206, 0.3);
+    box-shadow: 0 10px 25px rgba(59, 130, 246, 0.3);
+}
+
+.btn-outline {
+    background: transparent;
+    color: #3b82f6;
+    border: 2px solid #3b82f6;
+}
+
+.btn-outline:hover {
+    background: #3b82f6;
+    color: white;
+}
+
+.divider {
+    text-align: center;
+    margin: 20px 0;
+    position: relative;
+}
+
+.divider span {
+    background: white;
+    padding: 0 15px;
+    color: #9ca3af;
+    position: relative;
+}
+
+.divider::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: #e5e7eb;
 }
 
 .btn-find-tradies {
@@ -843,6 +906,21 @@ main {
 .recent-jobs,
 .trust-security {
     padding: 60px 0;
+}
+
+.trust-security .trust-badge {
+    background: white;
+    padding: 30px;
+    border-radius: 12px;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.05);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+}
+
+.trust-security .trust-badge .icon {
+    font-size: 2rem;
 }
 
 /* Mobile adjustments */


### PR DESCRIPTION
## Summary
- Embed trust badges inside hero search card with updated styling
- Redesign search form with left-aligned labels, icons and improved buttons
- Support extended urgency options and map urgent selections to availability flag

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fae84a200832e9d1ee529b8172be4