### PR TITLE
Add about, contact, and privacy pages

### DIFF
--- a/FindTradie.Web/Pages/About.razor
+++ b/FindTradie.Web/Pages/About.razor
@@ -1,0 +1,109 @@
+@page "/about"
+
+<div class="about-page">
+  <!-- Hero Section -->
+  <section class="hero-section-small">
+    <div class="container">
+      <h1>About FindTradie</h1>
+      <p class="hero-subtitle">Connecting Australians with trusted local tradies since 2024</p>
+    </div>
+  </section>
+
+  <!-- Mission Section -->
+  <section class="mission-section">
+    <div class="container">
+      <div class="content-grid">
+        <div class="content-left">
+          <h2>Our Mission</h2>
+          <p>We're on a mission to make home services simple, transparent, and trustworthy. FindTradie connects homeowners with verified, skilled professionals who deliver quality work at fair prices.</p>
+          <p>Every day, we help thousands of Australians find reliable tradies for everything from emergency repairs to dream renovations.</p>
+        </div>
+        <div class="content-right">
+          <img src="https://via.placeholder.com/600x400?text=FindTradie+Team" alt="FindTradie team" class="rounded-image">
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Values Section -->
+  <section class="values-section">
+    <div class="container">
+      <h2 class="text-center">Our Values</h2>
+      <div class="values-grid">
+        <div class="value-card">
+          <div class="value-icon">🛡️</div>
+          <h3>Trust &amp; Safety</h3>
+          <p>Every tradie is verified, background-checked, and carries appropriate insurance.</p>
+        </div>
+        <div class="value-card">
+          <div class="value-icon">⭐</div>
+          <h3>Quality First</h3>
+          <p>We maintain high standards through ratings, reviews, and quality guarantees.</p>
+        </div>
+        <div class="value-card">
+          <div class="value-icon">🤝</div>
+          <h3>Fair &amp; Transparent</h3>
+          <p>Clear pricing, no hidden fees, and honest communication between all parties.</p>
+        </div>
+        <div class="value-card">
+          <div class="value-icon">🚀</div>
+          <h3>Innovation</h3>
+          <p>Using technology to make finding and hiring tradies faster and easier than ever.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Stats Section -->
+  <section class="stats-section-about">
+    <div class="container">
+      <h2 class="text-center">FindTradie by the Numbers</h2>
+      <div class="stats-grid">
+        <div class="stat-item">
+          <div class="stat-number">500+</div>
+          <div class="stat-label">Verified Tradies</div>
+        </div>
+        <div class="stat-item">
+          <div class="stat-number">10,000+</div>
+          <div class="stat-label">Jobs Completed</div>
+        </div>
+        <div class="stat-item">
+          <div class="stat-number">4.8/5</div>
+          <div class="stat-label">Average Rating</div>
+        </div>
+        <div class="stat-item">
+          <div class="stat-number">24/7</div>
+          <div class="stat-label">Support Available</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Team Section -->
+  <section class="team-section">
+    <div class="container">
+      <h2 class="text-center">Leadership Team</h2>
+      <div class="team-grid">
+        <div class="team-member">
+          <div class="member-avatar">JD</div>
+          <h4>John Doe</h4>
+          <p class="member-role">CEO &amp; Founder</p>
+          <p class="member-bio">20+ years in construction industry</p>
+        </div>
+        <div class="team-member">
+          <div class="member-avatar">SM</div>
+          <h4>Sarah Miller</h4>
+          <p class="member-role">CTO</p>
+          <p class="member-bio">Former Google engineer, tech innovator</p>
+        </div>
+        <div class="team-member">
+          <div class="member-avatar">RC</div>
+          <h4>Robert Chen</h4>
+          <p class="member-role">Head of Operations</p>
+          <p class="member-bio">Operations expert, customer-focused</p>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+

--- a/FindTradie.Web/Pages/Contact.razor
+++ b/FindTradie.Web/Pages/Contact.razor
@@ -1,0 +1,124 @@
+@page "/contact"
+
+<div class="contact-page">
+  <!-- Hero Section -->
+  <section class="hero-section-small">
+    <div class="container">
+      <h1>Get in Touch</h1>
+      <p class="hero-subtitle">We're here to help with any questions or concerns</p>
+    </div>
+  </section>
+
+  <!-- Contact Options -->
+  <section class="contact-options">
+    <div class="container">
+      <div class="contact-grid">
+        <!-- Contact Form -->
+        <div class="contact-form-section">
+          <h2>Send us a message</h2>
+          <form class="contact-form">
+            <div class="form-group">
+              <label>Your Name</label>
+              <input type="text" class="form-control" placeholder="John Smith" required>
+            </div>
+            
+            <div class="form-group">
+              <label>Email Address</label>
+              <input type="email" class="form-control" placeholder="john@example.com" required>
+            </div>
+            
+            <div class="form-group">
+              <label>I am a...</label>
+              <select class="form-select">
+                <option>Customer</option>
+                <option>Tradie</option>
+                <option>Other</option>
+              </select>
+            </div>
+            
+            <div class="form-group">
+              <label>Subject</label>
+              <input type="text" class="form-control" placeholder="How can we help?" required>
+            </div>
+            
+            <div class="form-group">
+              <label>Message</label>
+              <textarea class="form-control" rows="5" placeholder="Tell us more..." required></textarea>
+            </div>
+            
+            <button type="submit" class="btn btn-primary btn-lg">
+              Send Message
+            </button>
+          </form>
+        </div>
+
+        <!-- Contact Information -->
+        <div class="contact-info-section">
+          <h2>Other ways to reach us</h2>
+          
+          <div class="contact-card">
+            <div class="contact-icon">📧</div>
+            <h4>Email Support</h4>
+            <p>support@findtradie.com.au</p>
+            <p class="text-muted">We'll respond within 24 hours</p>
+          </div>
+
+          <div class="contact-card">
+            <div class="contact-icon">📞</div>
+            <h4>Phone Support</h4>
+            <p>1300 TRADIE (1300 872 343)</p>
+            <p class="text-muted">Mon-Fri 8am-8pm, Sat-Sun 9am-5pm AEST</p>
+          </div>
+
+          <div class="contact-card">
+            <div class="contact-icon">💬</div>
+            <h4>Live Chat</h4>
+            <p>Available 24/7 on our website</p>
+            <button class="btn btn-outline">Start Chat</button>
+          </div>
+
+          <div class="contact-card">
+            <div class="contact-icon">📍</div>
+            <h4>Office Location</h4>
+            <p>Level 10, 123 Collins Street<br>
+               Melbourne VIC 3000<br>
+               Australia</p>
+          </div>
+
+          <div class="social-links">
+            <h4>Follow Us</h4>
+            <div class="social-icons">
+              <a href="#" class="social-icon">Facebook</a>
+              <a href="#" class="social-icon">Twitter</a>
+              <a href="#" class="social-icon">LinkedIn</a>
+              <a href="#" class="social-icon">Instagram</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- FAQ Section -->
+  <section class="faq-preview">
+    <div class="container">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq-grid">
+        <div class="faq-item">
+          <h4>How do I become a verified tradie?</h4>
+          <p>Apply online, pass our verification process, and start receiving job leads.</p>
+        </div>
+        <div class="faq-item">
+          <h4>Is FindTradie free for customers?</h4>
+          <p>Yes! It's completely free to post jobs and receive quotes.</p>
+        </div>
+        <div class="faq-item">
+          <h4>How quickly can I get a tradie?</h4>
+          <p>Emergency services available within hours, regular jobs within 24-48 hours.</p>
+        </div>
+      </div>
+      <a href="/faq" class="btn btn-outline">View All FAQs</a>
+    </div>
+  </section>
+</div>
+

--- a/FindTradie.Web/Pages/Home.razor
+++ b/FindTradie.Web/Pages/Home.razor
@@ -466,9 +466,9 @@
         <div>
             <h5>Company</h5>
             <ul class="footer-links">
-                <li><a href="#">About</a></li>
-                <li><a href="#">Contact</a></li>
-                <li><a href="#">Privacy</a></li>
+                <li><a href="/about">About</a></li>
+                <li><a href="/contact">Contact</a></li>
+                <li><a href="/privacy">Privacy</a></li>
             </ul>
         </div>
         <div>

--- a/FindTradie.Web/Pages/Privacy.razor
+++ b/FindTradie.Web/Pages/Privacy.razor
@@ -1,0 +1,144 @@
+@page "/privacy"
+
+<div class="privacy-page">
+  <!-- Hero Section -->
+  <section class="hero-section-small">
+    <div class="container">
+      <h1>Privacy Policy</h1>
+      <p class="hero-subtitle">Last updated: January 2025</p>
+    </div>
+  </section>
+
+  <!-- Privacy Content -->
+  <section class="legal-content">
+    <div class="container">
+      <div class="content-wrapper">
+        <!-- Table of Contents -->
+        <aside class="toc-sidebar">
+          <h3>Contents</h3>
+          <ul class="toc-list">
+            <li><a href="#overview">Overview</a></li>
+            <li><a href="#information">Information We Collect</a></li>
+            <li><a href="#usage">How We Use Information</a></li>
+            <li><a href="#sharing">Information Sharing</a></li>
+            <li><a href="#security">Data Security</a></li>
+            <li><a href="#rights">Your Rights</a></li>
+            <li><a href="#cookies">Cookies</a></li>
+            <li><a href="#contact">Contact Us</a></li>
+          </ul>
+        </aside>
+
+        <!-- Main Content -->
+        <div class="legal-main">
+          <section id="overview">
+            <h2>Overview</h2>
+            <p>FindTradie Pty Ltd ("we", "our", or "us") is committed to protecting your privacy. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you use our website and services.</p>
+            <p>By using FindTradie, you consent to the data practices described in this policy.</p>
+          </section>
+
+          <section id="information">
+            <h2>Information We Collect</h2>
+            <h3>Personal Information</h3>
+            <ul>
+              <li>Name and contact details (email, phone, address)</li>
+              <li>Account credentials</li>
+              <li>Payment information (processed securely via Stripe)</li>
+              <li>Business details for tradies (ABN, insurance, licenses)</li>
+              <li>Job history and preferences</li>
+            </ul>
+
+            <h3>Automatically Collected Information</h3>
+            <ul>
+              <li>IP address and device information</li>
+              <li>Browser type and version</li>
+              <li>Pages visited and time spent</li>
+              <li>Location data (with permission)</li>
+            </ul>
+          </section>
+
+          <section id="usage">
+            <h2>How We Use Your Information</h2>
+            <p>We use collected information to:</p>
+            <ul>
+              <li>Provide and maintain our services</li>
+              <li>Match customers with appropriate tradies</li>
+              <li>Process payments and transactions</li>
+              <li>Verify tradie credentials and insurance</li>
+              <li>Send service-related communications</li>
+              <li>Improve our platform and user experience</li>
+              <li>Comply with legal obligations</li>
+            </ul>
+          </section>
+
+          <section id="sharing">
+            <h2>Information Sharing</h2>
+            <p>We may share your information with:</p>
+            <ul>
+              <li><strong>Other Users:</strong> Basic profile info to facilitate connections</li>
+              <li><strong>Service Providers:</strong> Payment processors, email services, analytics</li>
+              <li><strong>Legal Requirements:</strong> When required by law or court order</li>
+              <li><strong>Business Transfers:</strong> In case of merger or acquisition</li>
+            </ul>
+            <p>We never sell your personal information to third parties.</p>
+          </section>
+
+          <section id="security">
+            <h2>Data Security</h2>
+            <p>We implement industry-standard security measures including:</p>
+            <ul>
+              <li>SSL/TLS encryption for data transmission</li>
+              <li>Secure data storage with encryption at rest</li>
+              <li>Regular security audits and updates</li>
+              <li>Limited access to personal information</li>
+              <li>PCI DSS compliance for payment processing</li>
+            </ul>
+          </section>
+
+          <section id="rights">
+            <h2>Your Rights</h2>
+            <p>Under Australian Privacy Law, you have the right to:</p>
+            <ul>
+              <li>Access your personal information</li>
+              <li>Correct inaccurate data</li>
+              <li>Request deletion of your data</li>
+              <li>Opt-out of marketing communications</li>
+              <li>Lodge a complaint with the OAIC</li>
+            </ul>
+            <p>To exercise these rights, contact us at privacy@findtradie.com.au</p>
+          </section>
+
+          <section id="cookies">
+            <h2>Cookies and Tracking</h2>
+            <p>We use cookies and similar technologies to:</p>
+            <ul>
+              <li>Remember your preferences</li>
+              <li>Authenticate your account</li>
+              <li>Analyze site usage</li>
+              <li>Personalize content</li>
+            </ul>
+            <p>You can control cookies through your browser settings.</p>
+          </section>
+
+          <section id="contact">
+            <h2>Contact Us</h2>
+            <p>For privacy-related questions or concerns:</p>
+            <div class="contact-box">
+              <p><strong>Privacy Officer</strong><br>
+              FindTradie Pty Ltd<br>
+              Level 10, 123 Collins Street<br>
+              Melbourne VIC 3000<br>
+              Email: privacy@findtradie.com.au<br>
+              Phone: 1300 872 343</p>
+            </div>
+          </section>
+
+          <section>
+            <h2>Updates to This Policy</h2>
+            <p>We may update this Privacy Policy periodically. We will notify you of significant changes via email or website notification.</p>
+          </section>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+

--- a/FindTradie.Web/wwwroot/css/site.css
+++ b/FindTradie.Web/wwwroot/css/site.css
@@ -1455,3 +1455,204 @@ h1, h2, h3, h4, h5, h6, p, span, div, label {
     }
 /* safety if empty */
 
+
+/* About, Contact, Privacy Page Styles */
+/* Common Styles for All Pages */
+.hero-section-small {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  padding: 60px 0;
+  color: white;
+  text-align: center;
+}
+
+.hero-section-small h1 {
+  font-size: 42px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+
+.hero-subtitle {
+  font-size: 20px;
+  opacity: 0.95;
+}
+
+/* About Page Styles */
+.mission-section,
+.values-section,
+.team-section {
+  padding: 80px 0;
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 60px;
+  align-items: center;
+}
+
+.rounded-image {
+  width: 100%;
+  border-radius: 12px;
+}
+
+.values-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 30px;
+  margin-top: 50px;
+}
+
+.value-card {
+  text-align: center;
+  padding: 30px;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+}
+
+.value-icon {
+  font-size: 48px;
+  margin-bottom: 20px;
+}
+
+.stats-section-about {
+  padding: 80px 0;
+  background: #f9fafb;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 40px;
+  margin-top: 40px;
+}
+
+.stat-item {
+  text-align: center;
+}
+
+.team-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 40px;
+  margin-top: 50px;
+}
+
+.team-member {
+  text-align: center;
+}
+
+.member-avatar {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 36px;
+  font-weight: bold;
+  margin: 0 auto 20px;
+}
+
+/* Contact Page Styles */
+.contact-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 60px;
+  margin-top: 50px;
+}
+
+.contact-form {
+  background: white;
+  padding: 40px;
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+}
+
+.contact-card {
+  background: white;
+  padding: 25px;
+  border-radius: 12px;
+  margin-bottom: 20px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.06);
+}
+
+.contact-icon {
+  font-size: 32px;
+  margin-bottom: 15px;
+}
+
+/* Privacy Page Styles */
+.legal-content {
+  padding: 60px 0;
+}
+
+.content-wrapper {
+  display: grid;
+  grid-template-columns: 250px 1fr;
+  gap: 60px;
+}
+
+.toc-sidebar {
+  position: sticky;
+  top: 100px;
+  height: fit-content;
+}
+
+.toc-list {
+  list-style: none;
+  padding: 0;
+}
+
+.toc-list li {
+  margin-bottom: 12px;
+}
+
+.toc-list a {
+  color: #64748b;
+  text-decoration: none;
+  transition: color 0.3s;
+}
+
+.toc-list a:hover {
+  color: #3b82f6;
+}
+
+.legal-main section {
+  margin-bottom: 50px;
+}
+
+.legal-main h2 {
+  color: #1a202c;
+  margin-bottom: 20px;
+  padding-bottom: 10px;
+  border-bottom: 2px solid #e5e7eb;
+}
+
+.contact-box {
+  background: #f8fafc;
+  padding: 20px;
+  border-radius: 8px;
+  border-left: 4px solid #3b82f6;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .content-grid,
+  .contact-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .content-wrapper {
+    grid-template-columns: 1fr;
+  }
+  
+  .toc-sidebar {
+    position: relative;
+    top: 0;
+    margin-bottom: 40px;
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add About page describing mission, values, stats, and team
- Add Contact page with form, contact methods, and FAQ preview
- Add Privacy Policy page with table of contents and detailed sections
- Style new pages with purple gradient hero and responsive layouts
- Wire up footer links and include placeholder team image
- Remove local team image to avoid binary file errors

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fb81db034832ea5cf85347e80f577