### PR TITLE
Add searchable Help Center and FAQ pages

### DIFF
--- a/FindTradie.Web/Pages/Faq.razor
+++ b/FindTradie.Web/Pages/Faq.razor
@@ -1,0 +1,220 @@
+@page "/faq"
+
+<PageTitle>FAQ • FindTradie</PageTitle>
+
+<link rel="stylesheet" href="css/help-faq.css" />
+
+<div class="faq-page">
+  <!-- Hero Section -->
+  <section class="hero-section-small">
+    <div class="container">
+      <h1>Frequently Asked Questions</h1>
+      <p class="hero-subtitle">Quick answers to common questions about FindTradie</p>
+    </div>
+  </section>
+
+  <!-- FAQ Categories Tabs -->
+  <section class="faq-section">
+    <div class="container">
+      <!-- Category Tabs -->
+      <div class="faq-tabs" role="tablist" aria-label="FAQ categories">
+        @foreach (var tab in Tabs)
+        {
+          <button class="faq-tab @(ActiveTab == tab ? "active" : "")"
+                  role="tab"
+                  aria-selected="@(ActiveTab == tab)"
+                  @onclick="() => SetTab(tab)">
+            @TabLabel(tab)
+          </button>
+        }
+      </div>
+
+      <!-- FAQ Content -->
+      <div class="faq-content">
+        @foreach (var (item, idx) in VisibleFaqs.Select((x, i) => (x, i)))
+        {
+          <div class="faq-item @(item.Open ? "open" : "")">
+            <button class="faq-question"
+                    aria-expanded="@item.Open"
+                    aria-controls="faq-@idx"
+                    @onclick="() => Toggle(idx)">
+              <span>@item.Question</span>
+              <span class="faq-icon" aria-hidden="true">@((item.Open ? "−" : "+"))</span>
+            </button>
+            <div id="faq-@idx" class="faq-answer" role="region">
+              @((MarkupString)item.AnswerHtml)
+            </div>
+          </div>
+        }
+      </div>
+    </div>
+  </section>
+
+  <!-- Still Have Questions -->
+  <section class="more-questions">
+    <div class="container">
+      <div class="questions-cta">
+        <h2>Didn't find your answer?</h2>
+        <p>Check our comprehensive Help Center or contact our support team</p>
+        <div class="cta-buttons">
+          <a href="/help" class="btn btn-outline">Visit Help Center</a>
+          <a href="/contact" class="btn btn-primary">Contact Support</a>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+
+@code {
+    private enum FaqCategory { General, Customers, Tradies, Payments, Safety }
+
+    private record Faq(string Question, string AnswerHtml, FaqCategory Category)
+    {
+        public bool Open { get; set; }
+    }
+
+    // Tabs order
+    private readonly FaqCategory[] Tabs = new[]
+    {
+        FaqCategory.General, FaqCategory.Customers, FaqCategory.Tradies, FaqCategory.Payments, FaqCategory.Safety
+    };
+
+    private FaqCategory ActiveTab = FaqCategory.General;
+    private List<Faq> VisibleFaqs => AllFaqs.Where(f => f.Category == ActiveTab).ToList();
+
+    private void SetTab(FaqCategory cat)
+    {
+        ActiveTab = cat;
+        // close all when switching
+        foreach (var f in AllFaqs) f.Open = false;
+    }
+
+    private void Toggle(int index)
+    {
+        var list = VisibleFaqs;
+        if (index < 0 || index >= list.Count) return;
+        list[index].Open = !list[index].Open;
+    }
+
+    private static string TabLabel(FaqCategory cat) => cat switch
+    {
+        FaqCategory.General => "General",
+        FaqCategory.Customers => "For Customers",
+        FaqCategory.Tradies => "For Tradies",
+        FaqCategory.Payments => "Payments",
+        FaqCategory.Safety => "Trust & Safety",
+        _ => cat.ToString()
+    };
+
+    // Content (expanded from your draft)
+    private readonly List<Faq> AllFaqs = new()
+    {
+        // General
+        new("What is FindTradie?", @"""
+            <p>FindTradie is Australia's trusted marketplace connecting homeowners with verified, insured local tradies. We make it easy to find reliable professionals for any home service, from emergency repairs to renovations.</p>
+            <p>All tradies undergo verification and are rated by real customers.</p>
+        """, FaqCategory.General),
+        new("How does FindTradie work?", @"""
+            <p>It's simple:</p>
+            <ol>
+              <li><strong>Post your job:</strong> Describe what you need done and add photos</li>
+              <li><strong>Receive quotes:</strong> Get quotes from interested local tradies</li>
+              <li><strong>Choose your tradie:</strong> Compare profiles, reviews, and prices</li>
+              <li><strong>Get it done:</strong> Your chosen tradie completes the work</li>
+              <li><strong>Leave a review:</strong> Help others by sharing your experience</li>
+            </ol>
+        """, FaqCategory.General),
+        new("Is FindTradie free to use?", @"""
+            <p>For customers: <strong>Yes, completely free!</strong> Post jobs and receive quotes at no cost.</p>
+            <p>For tradies: We offer flexible subscription plans starting from $99/month, with a 14-day free trial.</p>
+        """, FaqCategory.General),
+        new("Which areas does FindTradie service?", @"""
+            <p>We currently operate in major Australian cities and surrounding areas, including Sydney, Melbourne, Brisbane/Gold Coast, Perth, Adelaide, and Canberra. We're expanding soon—join the waitlist if your area isn't covered.</p>
+        """, FaqCategory.General),
+
+        // Customers
+        new("How do I post a job?", @"""
+            <p>Posting a job is easy:</p>
+            <ol>
+              <li>Click <em>Post a Job</em> on the homepage</li>
+              <li>Select the service you need</li>
+              <li>Describe the work required</li>
+              <li>Add photos (recommended)</li>
+              <li>Set your budget range and timeframe</li>
+              <li>Submit your job post</li>
+            </ol>
+            <p>You'll start receiving quotes within hours.</p>
+        """, FaqCategory.Customers),
+        new("How many quotes will I receive?", @"""
+            <p>Typically 3–5 quotes in 24–48 hours. This varies by job type, location, seasonality, and budget.</p>
+        """, FaqCategory.Customers),
+        new("What if I need emergency service?", @"""
+            <p>Select <strong>Emergency – ASAP</strong> when posting your job. We'll prioritise your request to available tradies—responses often arrive within 1–2 hours. For urgent hazards, call 1300 TRADIE.</p>
+        """, FaqCategory.Customers),
+        new("Can I cancel a job after accepting a quote?", @"""
+            <p>Yes, but timing matters:</p>
+            <ul>
+              <li><strong>>24 hours before:</strong> Free cancellation</li>
+              <li><strong><24 hours:</strong> A cancellation fee may apply</li>
+              <li><strong>After work starts:</strong> Subject to the tradie’s terms</li>
+            </ul>
+            <p>Always communicate with your tradie to reschedule or cancel.</p>
+        """, FaqCategory.Customers),
+
+        // Tradies
+        new("How do I become a verified tradie?", @"""
+            <p>Verification steps:</p>
+            <ol>
+              <li>Apply online (ABN, contact details)</li>
+              <li>Upload documents: public liability insurance (min $5M), licences, photo ID</li>
+              <li>Background & reference checks</li>
+              <li>Profile review by our team (2–3 business days)</li>
+            </ol>
+        """, FaqCategory.Tradies),
+        new("How much does it cost to join as a tradie?", @"""
+            <table class='pricing-table'>
+              <tr><td><strong>Starter</strong></td><td>$99/month</td><td>Up to 15 quotes/month</td></tr>
+              <tr><td><strong>Professional</strong></td><td>$199/month</td><td>Up to 40 quotes/month</td></tr>
+              <tr><td><strong>Business</strong></td><td>$399/month</td><td>Unlimited quotes</td></tr>
+            </table>
+            <p>All plans include a 14-day free trial. No setup fees.</p>
+        """, FaqCategory.Tradies),
+        new("How do I get more jobs?", @"""
+            <ul>
+              <li><strong>Complete your profile:</strong> Photos, certifications, services</li>
+              <li><strong>Respond quickly:</strong> Quotes within 2–4 hours perform best</li>
+              <li><strong>Write detailed quotes:</strong> Break down costs and approach</li>
+              <li><strong>Get reviews:</strong> Ask happy customers</li>
+              <li><strong>Show portfolio:</strong> Upload recent work</li>
+              <li><strong>Price competitively:</strong> Check local market rates</li>
+            </ul>
+        """, FaqCategory.Tradies),
+
+        // Payments
+        new("What payment methods are accepted?", @"""
+            <p>We accept Visa, Mastercard, Amex, PayPal, bank transfer, and Afterpay (for jobs over $500). Payments are processed securely via Stripe.</p>
+        """, FaqCategory.Payments),
+        new("When do I pay for the service?", @"""
+            <ul>
+              <li><strong>Small jobs (&lt;$500):</strong> Usually on completion</li>
+              <li><strong>Larger jobs:</strong> Often require a 10–30% deposit</li>
+              <li><strong>Projects:</strong> Milestone payments are common</li>
+            </ul>
+            <p>Never pay 100% upfront. Use our secure payment system for protection.</p>
+        """, FaqCategory.Payments),
+
+        // Safety
+        new("Are all tradies insured?", @"""
+            <p>Yes. Every tradie must hold public liability insurance (min $5M) with annual re-verification. Additional trade-specific cover may be required (e.g., electrical).</p>
+        """, FaqCategory.Safety),
+        new("What if something goes wrong?", @"""
+            <ol>
+              <li>Contact the tradie directly—most issues resolve quickly</li>
+              <li>Use our Resolution Center to lodge a complaint</li>
+              <li>Mediation support from our team if needed</li>
+              <li>Money-back guarantee for eligible cases under our protection policy</li>
+            </ol>
+            <p>Email <a href='mailto:support@findtradie.com.au'>support@findtradie.com.au</a> or call 1300 TRADIE.</p>
+        """, FaqCategory.Safety),
+    };
+}

--- a/FindTradie.Web/Pages/Help.razor
+++ b/FindTradie.Web/Pages/Help.razor
@@ -1,0 +1,363 @@
+@page "/help"
+@using System.Text.RegularExpressions
+
+<PageTitle>Help Center • FindTradie</PageTitle>
+
+<link rel="stylesheet" href="css/help-faq.css" />
+
+<div class="help-center-page">
+  <!-- Hero Section with Search -->
+  <section class="hero-section-help">
+    <div class="container">
+      <h1>How can we help you?</h1>
+      <p class="hero-subtitle">Find answers to your questions or contact our support team</p>
+
+      <div class="help-search-wrapper" role="search" aria-label="Help Center search">
+        <div class="help-search-box">
+          <span class="search-icon" aria-hidden="true">🔍</span>
+          <input
+            type="text"
+            class="help-search-input"
+            placeholder="Search for help articles... (e.g., 'post a job', 'get verified', 'payment')"
+            @bind="SearchTerm"
+            @bind:event="oninput"
+            @onkeydown="OnSearchKeydown"
+            aria-label="Search help articles" />
+
+          <button class="search-btn" @onclick="RunSearch" aria-label="Search">Search</button>
+        </div>
+
+        <!-- Live search results -->
+        @if (ShowResults)
+        {
+          <div class="help-search-results" role="listbox" aria-label="Search results">
+            @if (FilteredArticles.Count == 0)
+            {
+              <div class="no-results">No results for “@SearchTerm”. Try different keywords.</div>
+            }
+            else
+            {
+              @foreach (var a in FilteredArticles.Take(8))
+              {
+                <a class="result-item" href="@a.Url" role="option">
+                  <div class="result-title">@a.Title</div>
+                  <div class="result-meta">@a.Audience • @a.Category</div>
+                </a>
+              }
+            }
+          </div>
+        }
+
+        <!-- Quick search suggestions -->
+        <div class="quick-searches">
+          <span>Popular searches:</span>
+          <button type="button" class="quick-link" @onclick='() => QuickSearch("How to post a job")'>How to post a job</button>
+          <button type="button" class="quick-link" @onclick='() => QuickSearch("Verification process")'>Verification process</button>
+          <button type="button" class="quick-link" @onclick='() => QuickSearch("Payment methods")'>Payment methods</button>
+          <button type="button" class="quick-link" @onclick='() => QuickSearch("Cancel a job")'>Cancel a job</button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- User Type Selection -->
+  <section class="user-type-help">
+    <div class="container">
+      <h2 class="text-center">I need help as a...</h2>
+      <div class="user-type-cards" role="tablist" aria-label="Help audience">
+        <button class="user-card customer-card @(IsCustomerView ? "active" : "")"
+                role="tab"
+                aria-selected="@IsCustomerView"
+                @onclick="() => SetAudience(true)">
+          <div class="user-icon">🏠</div>
+          <h3>Customer</h3>
+          <p>I need to hire a tradie</p>
+          <span class="card-arrow" aria-hidden="true">→</span>
+        </button>
+
+        <button class="user-card tradie-card @(!IsCustomerView ? "active" : "")"
+                role="tab"
+                aria-selected="@(!IsCustomerView)"
+                @onclick="() => SetAudience(false)">
+          <div class="user-icon">🔧</div>
+          <h3>Tradie</h3>
+          <p>I provide services</p>
+          <span class="card-arrow" aria-hidden="true">→</span>
+        </button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Help Categories Grid -->
+  <section class="help-categories">
+    <div class="container">
+      <h2>Browse Help Topics</h2>
+
+      <!-- Customer Help Topics -->
+      @if (IsCustomerView)
+      {
+        <div id="customer-topics" class="help-topics-grid" role="region" aria-label="Customer help topics">
+          <div class="help-category-card">
+            <div class="category-icon">📝</div>
+            <h3>Getting Started</h3>
+            <ul class="help-links">
+              <li><a href="/help/create-account">Create an account</a></li>
+              <li><a href="/help/post-first-job">Post your first job</a></li>
+              <li><a href="/help/how-it-works">How FindTradie works</a></li>
+              <li><a href="/help/service-areas">Service areas</a></li>
+            </ul>
+          </div>
+
+          <div class="help-category-card">
+            <div class="category-icon">💼</div>
+            <h3>Posting Jobs</h3>
+            <ul class="help-links">
+              <li><a href="/help/job-details">Writing job descriptions</a></li>
+              <li><a href="/help/add-photos">Adding photos</a></li>
+              <li><a href="/help/set-budget">Setting your budget</a></li>
+              <li><a href="/help/emergency-jobs">Emergency jobs</a></li>
+            </ul>
+          </div>
+
+          <div class="help-category-card">
+            <div class="category-icon">📋</div>
+            <h3>Managing Quotes</h3>
+            <ul class="help-links">
+              <li><a href="/help/review-quotes">Reviewing quotes</a></li>
+              <li><a href="/help/compare-tradies">Comparing tradies</a></li>
+              <li><a href="/help/accept-quote">Accepting a quote</a></li>
+              <li><a href="/help/negotiate">Negotiating prices</a></li>
+            </ul>
+          </div>
+
+          <div class="help-category-card">
+            <div class="category-icon">💳</div>
+            <h3>Payments & Billing</h3>
+            <ul class="help-links">
+              <li><a href="/help/payment-methods">Payment methods</a></li>
+              <li><a href="/help/secure-payment">Secure payment system</a></li>
+              <li><a href="/help/invoices">Invoices & receipts</a></li>
+              <li><a href="/help/refunds">Refunds & disputes</a></li>
+            </ul>
+          </div>
+
+          <div class="help-category-card">
+            <div class="category-icon">⭐</div>
+            <h3>Reviews & Ratings</h3>
+            <ul class="help-links">
+              <li><a href="/help/leave-review">Leaving reviews</a></li>
+              <li><a href="/help/rating-system">Rating system</a></li>
+              <li><a href="/help/review-guidelines">Review guidelines</a></li>
+              <li><a href="/help/report-review">Report inappropriate reviews</a></li>
+            </ul>
+          </div>
+
+          <div class="help-category-card">
+            <div class="category-icon">🚡️</div>
+            <h3>Trust & Safety</h3>
+            <ul class="help-links">
+              <li><a href="/help/verified-tradies">Verified tradies</a></li>
+              <li><a href="/help/insurance">Insurance coverage</a></li>
+              <li><a href="/help/safety-tips">Safety tips</a></li>
+              <li><a href="/help/report-issue">Report an issue</a></li>
+            </ul>
+          </div>
+        </div>
+      }
+      else
+      {
+        <!-- Tradie Help Topics -->
+        <div id="tradie-topics" class="help-topics-grid" role="region" aria-label="Tradie help topics">
+          <div class="help-category-card">
+            <div class="category-icon">🚀</div>
+            <h3>Getting Started</h3>
+            <ul class="help-links">
+              <li><a href="/help/tradie-signup">Sign up as a tradie</a></li>
+              <li><a href="/help/verification">Verification process</a></li>
+              <li><a href="/help/profile-setup">Set up your profile</a></li>
+              <li><a href="/help/subscription-plans">Subscription plans</a></li>
+            </ul>
+          </div>
+
+          <div class="help-category-card">
+            <div class="category-icon">🔍</div>
+            <h3>Finding Work</h3>
+            <ul class="help-links">
+              <li><a href="/help/browse-jobs">Browse available jobs</a></li>
+              <li><a href="/help/job-alerts">Set up job alerts</a></li>
+              <li><a href="/help/service-areas">Set service areas</a></li>
+              <li><a href="/help/availability">Manage availability</a></li>
+            </ul>
+          </div>
+
+          <div class="help-category-card">
+            <div class="category-icon">💰</div>
+            <h3>Quoting & Pricing</h3>
+            <ul class="help-links">
+              <li><a href="/help/create-quote">Creating quotes</a></li>
+              <li><a href="/help/pricing-guide">Pricing guidelines</a></li>
+              <li><a href="/help/quote-templates">Quote templates</a></li>
+              <li><a href="/help/win-more-jobs">Tips to win jobs</a></li>
+            </ul>
+          </div>
+
+          <div class="help-category-card">
+            <div class="category-icon">📊</div>
+            <h3>Growing Your Business</h3>
+            <ul class="help-links">
+              <li><a href="/help/profile-optimization">Optimize your profile</a></li>
+              <li><a href="/help/get-reviews">Getting reviews</a></li>
+              <li><a href="/help/ranking">Improve ranking</a></li>
+              <li><a href="/help/analytics">View analytics</a></li>
+            </ul>
+          </div>
+        </div>
+      }
+    </div>
+  </section>
+
+  <!-- Video Tutorials -->
+  <section class="video-tutorials">
+    <div class="container">
+      <h2>Video Tutorials</h2>
+      <div class="video-grid">
+        <a class="video-card" href="/help/video/post-job">
+          <div class="video-thumbnail">
+            <span class="play-icon">▶️</span>
+          </div>
+          <h4>How to Post a Job</h4>
+          <p>2 min watch</p>
+        </a>
+        <a class="video-card" href="/help/video/choose-tradie">
+          <div class="video-thumbnail">
+            <span class="play-icon">▶️</span>
+          </div>
+          <h4>Choosing the Right Tradie</h4>
+          <p>3 min watch</p>
+        </a>
+        <a class="video-card" href="/help/video/verification">
+          <div class="video-thumbnail">
+            <span class="play-icon">▶️</span>
+          </div>
+          <h4>Tradie Verification Process</h4>
+          <p>4 min watch</p>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Contact Support -->
+  <section class="contact-support-section">
+    <div class="container">
+      <div class="support-cta">
+        <h2>Still need help?</h2>
+        <p>Our support team is here to assist you</p>
+        <div class="support-options">
+          <a href="/contact" class="support-option">
+            <span class="option-icon">💬</span>
+            <h4>Live Chat</h4>
+            <p>Chat with our team</p>
+          </a>
+          <a href="mailto:support@findtradie.com.au" class="support-option">
+            <span class="option-icon">📧</span>
+            <h4>Email Support</h4>
+            <p>Get help via email</p>
+          </a>
+          <a href="tel:1300872343" class="support-option">
+            <span class="option-icon">📞</span>
+            <h4>Call Us</h4>
+            <p>1300 TRADIE</p>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+
+@code {
+    private bool IsCustomerView = true;
+    private string SearchTerm = string.Empty;
+    private bool ShowResults => !string.IsNullOrWhiteSpace(SearchTerm);
+    private List<HelpArticle> FilteredArticles = new();
+
+    private record HelpArticle(string Title, string Url, string Audience, string Category, string[] Keywords);
+
+    // Minimal index; add more as you create articles
+    private readonly List<HelpArticle> Index = new()
+    {
+        new("Create an account", "/help/create-account", "Customer", "Getting Started", new[] { "signup","register","account","login" }),
+        new("Post your first job", "/help/post-first-job", "Customer", "Getting Started", new[] { "post job","job","create job","new job" }),
+        new("How FindTradie works", "/help/how-it-works", "Both", "Getting Started", new[] { "how it works","overview","guide" }),
+        new("Service areas", "/help/service-areas", "Both", "Getting Started", new[] { "locations","coverage","areas" }),
+        new("Writing job descriptions", "/help/job-details", "Customer", "Posting Jobs", new[] { "description","scope","details" }),
+        new("Adding photos", "/help/add-photos", "Customer", "Posting Jobs", new[] { "images","photos","attachments" }),
+        new("Setting your budget", "/help/set-budget", "Customer", "Posting Jobs", new[] { "price","cost","budget" }),
+        new("Emergency jobs", "/help/emergency-jobs", "Customer", "Posting Jobs", new[] { "asap","urgent","emergency" }),
+        new("Reviewing quotes", "/help/review-quotes", "Customer", "Managing Quotes", new[] { "quotes","compare","offers" }),
+        new("Comparing tradies", "/help/compare-tradies", "Customer", "Managing Quotes", new[] { "compare","ratings","profiles" }),
+        new("Accepting a quote", "/help/accept-quote", "Customer", "Managing Quotes", new[] { "accept","approve","hire" }),
+        new("Negotiating prices", "/help/negotiate", "Customer", "Managing Quotes", new[] { "negotiate","price","counter" }),
+        new("Payment methods", "/help/payment-methods", "Both", "Payments", new[] { "card","paypal","bank","afterpay","payment" }),
+        new("Secure payment system", "/help/secure-payment", "Both", "Payments", new[] { "security","stripe","escrow" }),
+        new("Invoices & receipts", "/help/invoices", "Both", "Payments", new[] { "invoice","receipt","billing" }),
+        new("Refunds & disputes", "/help/refunds", "Both", "Payments", new[] { "refund","chargeback","dispute" }),
+        new("Leaving reviews", "/help/leave-review", "Customer", "Reviews", new[] { "review","rating","feedback" }),
+        new("Rating system", "/help/rating-system", "Both", "Reviews", new[] { "stars","score","ratings" }),
+        new("Review guidelines", "/help/review-guidelines", "Both", "Reviews", new[] { "policy","guidelines","rules" }),
+        new("Report inappropriate reviews", "/help/report-review", "Both", "Reviews", new[] { "report","flag","abuse" }),
+        new("Verified tradies", "/help/verified-tradies", "Both", "Trust & Safety", new[] { "verify","background","check" }),
+        new("Insurance coverage", "/help/insurance", "Both", "Trust & Safety", new[] { "insurance","liability","coverage" }),
+        new("Safety tips", "/help/safety-tips", "Both", "Trust & Safety", new[] { "safety","tips","onsite" }),
+        new("Report an issue", "/help/report-issue", "Both", "Trust & Safety", new[] { "complaint","issue","problem" }),
+        new("Sign up as a tradie", "/help/tradie-signup", "Tradie", "Getting Started", new[] { "join","signup","tradie account" }),
+        new("Verification process", "/help/verification", "Tradie", "Getting Started", new[] { "verify","documents","id","abn","insurance" }),
+        new("Set up your profile", "/help/profile-setup", "Tradie", "Getting Started", new[] { "profile","photo","bio","services" }),
+        new("Subscription plans", "/help/subscription-plans", "Tradie", "Getting Started", new[] { "pricing","plans","trial" }),
+        new("Browse available jobs", "/help/browse-jobs", "Tradie", "Finding Work", new[] { "jobs","feed","browse" }),
+        new("Set up job alerts", "/help/job-alerts", "Tradie", "Finding Work", new[] { "alerts","notifications" }),
+        new("Set service areas", "/help/service-areas", "Tradie", "Finding Work", new[] { "areas","distance","radius" }),
+        new("Manage availability", "/help/availability", "Tradie", "Finding Work", new[] { "availability","calendar","schedule" }),
+        new("Creating quotes", "/help/create-quote", "Tradie", "Quoting & Pricing", new[] { "quote","proposal" }),
+        new("Pricing guidelines", "/help/pricing-guide", "Tradie", "Quoting & Pricing", new[] { "pricing","rates" }),
+        new("Quote templates", "/help/quote-templates", "Tradie", "Quoting & Pricing", new[] { "template","sample" }),
+        new("Tips to win jobs", "/help/win-more-jobs", "Tradie", "Quoting & Pricing", new[] { "win","convert","best practices" }),
+        new("Optimize your profile", "/help/profile-optimization", "Tradie", "Growing Your Business", new[] { "optimize","ranking" }),
+        new("Getting reviews", "/help/get-reviews", "Tradie", "Growing Your Business", new[] { "reviews","ask","follow up" }),
+        new("Improve ranking", "/help/ranking", "Tradie", "Growing Your Business", new[] { "ranking","quality","responsiveness" }),
+        new("View analytics", "/help/analytics", "Tradie", "Growing Your Business", new[] { "analytics","performance" }),
+    };
+
+    private void SetAudience(bool customer) => IsCustomerView = customer;
+
+    private void QuickSearch(string term)
+    {
+        SearchTerm = term;
+        RunSearch();
+    }
+
+    private void OnSearchKeydown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter") RunSearch();
+    }
+
+    private void RunSearch()
+    {
+        if (string.IsNullOrWhiteSpace(SearchTerm))
+        {
+            FilteredArticles = new();
+            return;
+        }
+
+        var term = SearchTerm.Trim();
+        // Case-insensitive contains on title + keywords
+        FilteredArticles = Index
+            .Where(a =>
+                a.Title.Contains(term, StringComparison.OrdinalIgnoreCase) ||
+                a.Category.Contains(term, StringComparison.OrdinalIgnoreCase) ||
+                a.Audience.Contains(term, StringComparison.OrdinalIgnoreCase) ||
+                a.Keywords.Any(k => k.Contains(term, StringComparison.OrdinalIgnoreCase)))
+            .OrderBy(a => a.Audience == (IsCustomerView ? "Customer" : "Tradie") ? 0 : 1) // bias to selected audience
+            .ThenBy(a => a.Title)
+            .ToList();
+    }
+}

--- a/FindTradie.Web/Shared/NavMenu.razor
+++ b/FindTradie.Web/Shared/NavMenu.razor
@@ -13,6 +13,8 @@
                 <NavLink href="/find-tradies" class="nav-link">Find Tradies</NavLink>
                 <NavLink href="/how-it-works" class="nav-link">How It Works</NavLink>
                 <NavLink href="/post-job" class="nav-link">Post a Job</NavLink>
+                <NavLink href="/help" class="nav-link">Help Center</NavLink>
+                <NavLink href="/faq" class="nav-link">FAQ</NavLink>
             </nav>
         </div>
         <div class="header-right">
@@ -37,6 +39,8 @@
         <NavLink href="/find-tradies" class="nav-link" @onclick="ToggleNavMenu">Find Tradies</NavLink>
         <NavLink href="/how-it-works" class="nav-link" @onclick="ToggleNavMenu">How It Works</NavLink>
         <NavLink href="/post-job" class="nav-link" @onclick="ToggleNavMenu">Post a Job</NavLink>
+        <NavLink href="/help" class="nav-link" @onclick="ToggleNavMenu">Help Center</NavLink>
+        <NavLink href="/faq" class="nav-link" @onclick="ToggleNavMenu">FAQ</NavLink>
         <AuthorizeView>
             <Authorized>
                 <LoginDisplay />

--- a/FindTradie.Web/wwwroot/css/help-faq.css
+++ b/FindTradie.Web/wwwroot/css/help-faq.css
@@ -1,0 +1,129 @@
+/* ========== Shared ========== */
+.container { max-width: 1080px; margin: 0 auto; padding: 0 16px; }
+.text-center { text-align: center; }
+.btn { display:inline-flex; align-items:center; justify-content:center; padding:12px 20px; border-radius:10px; font-weight:600; text-decoration:none; }
+.btn-primary { background:#3b82f6; color:#fff; border:none; }
+.btn-primary:hover { background:#2563eb; }
+.btn-outline { border:2px solid #3b82f6; color:#3b82f6; background:transparent; }
+.btn-outline:hover { background:#3b82f6; color:#fff; }
+
+/* ========== Help Center Styles ========== */
+.hero-section-help {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  padding: 80px 0 96px;
+  color: white;
+  text-align: center;
+}
+.hero-section-help .hero-subtitle { opacity:.95; }
+
+.help-search-wrapper { max-width: 700px; margin: 40px auto 0; position: relative; }
+.help-search-box {
+  background: white; border-radius: 50px; padding: 8px; display: flex; align-items: center;
+  box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+}
+.search-icon { padding: 0 20px; font-size: 20px; }
+.help-search-input {
+  flex: 1; border: none; padding: 14px 0; font-size: 16px; outline: none; color: #333; background: transparent;
+}
+.search-btn {
+  background: #3b82f6; color: white; border: none; padding: 12px 32px; border-radius: 50px; font-weight: 600; cursor: pointer; transition: all 0.3s;
+}
+.search-btn:hover { background: #2563eb; transform: translateY(-1px); }
+
+.help-search-results {
+  position: absolute; left: 0; right: 0; top: calc(100% + 10px);
+  background: #fff; border-radius: 14px; box-shadow: 0 20px 50px rgba(0,0,0,.15); overflow: hidden; z-index: 5;
+}
+.result-item { display:block; padding:14px 16px; color:#0f172a; text-decoration:none; border-bottom:1px solid #f1f5f9; }
+.result-item:hover { background:#f8fafc; }
+.result-title { font-weight:600; }
+.result-meta { font-size:12px; color:#64748b; margin-top:2px; }
+.no-results { padding:16px; color:#64748b; }
+
+.quick-searches { margin-top: 18px; color: rgba(255,255,255,0.9); display:flex; gap:8px; flex-wrap:wrap; align-items:center; justify-content:center; }
+.quick-searches span { opacity:.9; }
+.quick-link {
+  background: transparent; border: 0; color: #fff; text-decoration: underline; cursor: pointer; opacity: .9; padding: 0 2px;
+}
+.quick-link:hover { opacity: 1; }
+
+/* User Type Cards */
+.user-type-help { padding: 60px 0; background: #f8fafc; }
+.user-type-cards { display: grid; grid-template-columns: repeat(2, 1fr); gap: 30px; max-width: 600px; margin: 40px auto; }
+.user-card {
+  background: white; padding: 40px; border-radius: 16px; text-align: center; cursor: pointer; transition: all 0.25s ease;
+  position: relative; border: 2px solid transparent; width:100%;
+}
+.user-card:hover, .user-card.active { transform: translateY(-6px); box-shadow: 0 20px 40px rgba(0,0,0,0.1); border-color: #3b82f6; }
+.user-card h3 { margin: 8px 0 6px; }
+.user-card p { margin: 0; color:#475569; }
+.user-icon { font-size: 48px; margin-bottom: 12px; }
+.card-arrow { position: absolute; top: 18px; right: 18px; font-size: 20px; color: #3b82f6; opacity: 0; transition: all 0.3s; }
+.user-card:hover .card-arrow, .user-card.active .card-arrow { opacity: 1; transform: translateX(4px); }
+
+/* Help Categories */
+.help-categories { padding: 80px 0; }
+.help-topics-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 30px; margin-top: 28px; }
+.help-category-card {
+  background: white; padding: 26px; border-radius: 12px; box-shadow: 0 2px 10px rgba(0,0,0,0.08); transition: all 0.25s ease;
+}
+.help-category-card:hover { transform: translateY(-4px); box-shadow: 0 10px 30px rgba(0,0,0,0.15); }
+.category-icon { font-size: 32px; margin-bottom: 10px; }
+.help-links { list-style: none; padding: 0; margin: 0; }
+.help-links li { margin-bottom: 10px; }
+.help-links a { color: #334155; text-decoration: none; transition: all 0.25s ease; display: inline-block; }
+.help-links a:hover { color: #3b82f6; transform: translateX(5px); }
+
+/* Video Tutorials */
+.video-tutorials { background: #f8fafc; padding: 60px 0; }
+.video-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 24px; margin-top: 22px; }
+.video-card {
+  background: white; border-radius: 12px; overflow: hidden; text-decoration:none; color:#0f172a; border:1px solid #f1f5f9;
+  transition: transform .2s ease, box-shadow .2s ease;
+}
+.video-card:hover { transform: translateY(-3px); box-shadow: 0 12px 30px rgba(0,0,0,.12); }
+.video-thumbnail { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); height: 140px; position: relative; display:flex; align-items:center; justify-content:center; }
+.play-icon { font-size: 38px; color:#fff; filter: drop-shadow(0 2px 8px rgba(0,0,0,.3)); }
+.video-card h4 { margin: 12px 16px 4px; }
+.video-card p { margin: 0 16px 16px; color:#64748b; }
+
+/* Contact Support */
+.contact-support-section { padding: 60px 0 100px; }
+.support-cta { background: #111827; color: #fff; border-radius: 16px; padding: 32px; text-align: center; }
+.support-options { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; margin-top: 18px; }
+.support-option {
+  background: #1f2937; color: #fff; border-radius: 12px; padding: 16px; text-decoration:none; transition: transform .2s ease, background .2s ease;
+}
+.support-option:hover { transform: translateY(-2px); background:#374151; }
+.option-icon { font-size:24px; display:block; margin-bottom:6px; }
+
+/* ========== FAQ Styles ========== */
+.hero-section-small { background: #f8fafc; padding: 64px 0 56px; text-align: center; }
+.faq-section { padding: 48px 0 90px; }
+.faq-tabs { display:flex; gap:10px; flex-wrap:wrap; justify-content:center; margin-bottom:22px; }
+.faq-tab {
+  background:#e2e8f0; border:none; padding:10px 16px; border-radius:999px; cursor:pointer; font-weight:600; color:#334155;
+}
+.faq-tab.active { background:#3b82f6; color:#fff; }
+
+.faq-content { max-width: 860px; margin: 0 auto; }
+.faq-item { border:1px solid #e5e7eb; border-radius:12px; margin-bottom:12px; overflow:hidden; background:#fff; }
+.faq-question {
+  width:100%; text-align:left; background:#fff; border:none; padding:16px 18px; font-weight:600; display:flex; align-items:center; justify-content:space-between; cursor:pointer;
+}
+.faq-icon { font-size:20px; color:#64748b; }
+.faq-answer { display:none; padding:0 18px 18px; color:#475569; }
+.faq-item.open .faq-answer { display:block; }
+.pricing-table { width:100%; border-collapse:collapse; margin: 6px 0 6px; }
+.pricing-table td { border-bottom:1px solid #f1f5f9; padding:8px 6px; }
+
+/* More Questions CTA */
+.more-questions { background: #f8fafc; padding: 48px 0 100px; }
+.questions-cta { background:#fff; border:1px solid #e5e7eb; border-radius:16px; padding:24px; text-align:center; }
+
+/* ========== Responsive tweaks ========== */
+@media (max-width: 640px){
+  .help-search-box { border-radius: 16px; }
+  .search-btn { padding: 10px 18px; }
+  .user-type-cards { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Summary
- add Help Center page with live search and audience-specific topics
- create FAQ page with categorized, expandable questions
- include dedicated styling and navigation links to Help Center and FAQ

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689fc3ef2834832eb9801856a915f851