### PR TITLE
Align gateway port with web client configuration

### DIFF
--- a/FindTradie.Gateway.API/FindTradie.Gateway.API.http
+++ b/FindTradie.Gateway.API/FindTradie.Gateway.API.http
@@ -1,4 +1,4 @@
-@FindTradie.Gateway.API_HostAddress = http://localhost:5047
+@FindTradie.Gateway.API_HostAddress = https://localhost:7000
 
 GET {{FindTradie.Gateway.API_HostAddress}}/weatherforecast/
 Accept: application/json

--- a/FindTradie.Gateway.API/Properties/launchSettings.json
+++ b/FindTradie.Gateway.API/Properties/launchSettings.json
@@ -14,7 +14,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:5047",
+      "applicationUrl": "http://localhost:7001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -24,7 +24,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7134;http://localhost:5047",
+      "applicationUrl": "https://localhost:7000;http://localhost:7001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
## Summary
- configure gateway launch profiles to run on ports 7000/7001
- update gateway HTTP file to target new port

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689fe8c55e88832ea7e4a6bee01ad3ad