### PR TITLE
Ensure UserProfileDto has parameterless constructor for AutoMapper

### DIFF
--- a/FindTradie.Shared.Contracts/DTOs/UserDtos.cs
+++ b/FindTradie.Shared.Contracts/DTOs/UserDtos.cs
@@ -11,16 +11,17 @@ public record CreateUserRequest(
     UserType UserType
 );
 
-public record UserProfileDto(
-    Guid Id,
-    string Email,
-    string FirstName,
-    string LastName,
-    string PhoneNumber,
-    UserType UserType,
-    DateTime CreatedAt,
-    bool IsVerified
-);
+public record UserProfileDto
+{
+    public Guid Id { get; init; }
+    public string Email { get; init; } = string.Empty;
+    public string FirstName { get; init; } = string.Empty;
+    public string LastName { get; init; } = string.Empty;
+    public string PhoneNumber { get; init; } = string.Empty;
+    public UserType UserType { get; init; }
+    public DateTime CreatedAt { get; init; }
+    public bool IsVerified { get; init; }
+}
 
 public record TradieProfileDto(
     Guid Id,


### PR DESCRIPTION
## Summary
- convert UserProfileDto to property-based record with init-only setters to allow AutoMapper to construct the DTO

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ff35b80e0832e8380f6eda3e44a80