### PR TITLE
Add user login endpoint with JWT generation

### DIFF
--- a/FindTradie.Services.UserManagement/Controllers/UsersController.cs
+++ b/FindTradie.Services.UserManagement/Controllers/UsersController.cs
@@ -41,6 +41,26 @@ public class UsersController : ControllerBase
         }
     }
 
+    [HttpPost("login")]
+    public async Task<ActionResult<ApiResponse<string>>> Login([FromBody] LoginRequest request)
+    {
+        try
+        {
+            var result = await _userService.LoginAsync(request.Email, request.Password);
+            if (!result.Success)
+            {
+                return Unauthorized(result);
+            }
+
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error logging in user {Email}", request.Email);
+            return Unauthorized(ApiResponse<string>.ErrorResult("Login failed"));
+        }
+    }
+
     [HttpGet("{id}")]
     public async Task<ActionResult<ApiResponse<UserProfileDto>>> GetUser(Guid id)
     {

--- a/FindTradie.Services.UserManagement/Services/IUserService.cs
+++ b/FindTradie.Services.UserManagement/Services/IUserService.cs
@@ -15,4 +15,5 @@ public interface IUserService
     Task<ApiResponse<bool>> DeleteUserAsync(Guid id);
     Task<ApiResponse<bool>> VerifyEmailAsync(Guid id);
     Task<ApiResponse<bool>> VerifyPhoneAsync(Guid id);
+    Task<ApiResponse<string>> LoginAsync(string email, string password);
 }

--- a/FindTradie.Shared.Contracts/DTOs/UserDtos.cs
+++ b/FindTradie.Shared.Contracts/DTOs/UserDtos.cs
@@ -11,6 +11,11 @@ public record CreateUserRequest(
     UserType UserType
 );
 
+public record LoginRequest(
+    string Email,
+    string Password
+);
+
 public record UserProfileDto
 {
     public Guid Id { get; init; }


### PR DESCRIPTION
## Summary
- add `LoginRequest` DTO for user logins
- implement authentication logic with JWT token issuance and LastLoginAt update
- expose `/api/users/login` endpoint

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ff590672c832e86c16edfb48c4aae