### PR TITLE
Fix router authentication view and home redirect

### DIFF
--- a/FindTradie.Web/App.razor
+++ b/FindTradie.Web/App.razor
@@ -1,14 +1,7 @@
 <CascadingAuthenticationState>
     <Router AppAssembly="@typeof(App).Assembly">
         <Found Context="routeData">
-            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
-                <Authorized>
-                    @if (routeData.PageType == typeof(FindTradie.Web.Pages.Home))
-                    {
-                        <RedirectToComponent Component="@typeof(FindTradie.Web.Pages.Dashboard)" />
-                    }
-                </Authorized>
-            </AuthorizeRouteView>
+            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
         </Found>
         <NotFound>
             <p>Sorry, nothing here.</p>

--- a/FindTradie.Web/Pages/Home.razor
+++ b/FindTradie.Web/Pages/Home.razor
@@ -1,8 +1,10 @@
 @page "/"
 @using FindTradie.Services.TradieManagement.DTOs
 @using FindTradie.Shared.Domain.Enums
+@using Microsoft.AspNetCore.Components.Authorization
 @inject FindTradie.Web.Services.ITradieApiService TradieService
 @inject NavigationManager Navigation
+@inject AuthenticationStateProvider AuthStateProvider
 
 <PageTitle>FindTradie - Find Trusted Local Tradies</PageTitle>
 
@@ -550,6 +552,15 @@
         { ServiceCategory.Handyman, "Handyman" }
     };
 
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+
+        if (authState.User.Identity?.IsAuthenticated == true)
+        {
+            Navigation.NavigateTo("/dashboard", true);
+        }
+    }
 
     private async Task SearchTradies()
     {


### PR DESCRIPTION
## Summary
- remove unsupported `Authorized` block from `AuthorizeRouteView`
- redirect authenticated users from Home page to Dashboard

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a017698548832e863a001619d98692