### PR TITLE
feat: add job browsing page

### DIFF
--- a/FindTradie.Web/Pages/BrowseJobs.razor
+++ b/FindTradie.Web/Pages/BrowseJobs.razor
@@ -1,0 +1,421 @@
+@page "/browse-jobs"
+@using FindTradie.Web.Services
+@inject IJobApiService JobService
+@inject NavigationManager Navigation
+@inject AuthenticationStateProvider AuthStateProvider
+
+<PageTitle>Browse Jobs - FindTradie</PageTitle>
+
+<div class="browse-jobs-page">
+    <!-- Header Section -->
+    <div class="page-header">
+        <div class="container">
+            <h1>Available Jobs in Your Area</h1>
+            <p class="text-muted">Find and quote on jobs that match your skills</p>
+        </div>
+    </div>
+
+    <!-- Filters and Search Bar -->
+    <div class="filters-section">
+        <div class="container">
+            <div class="row g-3">
+                <!-- Search Bar -->
+                <div class="col-lg-4">
+                    <div class="search-wrapper">
+                        <i class="bi bi-search search-icon"></i>
+                        <input type="text" class="form-control search-input" 
+                               placeholder="Search jobs by keyword..." 
+                               @bind="searchTerm" 
+                               @oninput="@((e) => OnSearchChanged(e.Value.ToString()))" />
+                    </div>
+                </div>
+
+                <!-- Category Filter -->
+                <div class="col-lg-2">
+                    <select class="form-select" @bind="selectedCategory">
+                        <option value="">All Categories</option>
+                        <option value="plumbing">Plumbing</option>
+                        <option value="electrical">Electrical</option>
+                        <option value="carpentry">Carpentry</option>
+                        <option value="painting">Painting</option>
+                        <option value="landscaping">Landscaping</option>
+                        <option value="hvac">HVAC</option>
+                        <option value="roofing">Roofing</option>
+                        <option value="tiling">Tiling</option>
+                    </select>
+                </div>
+
+                <!-- Distance Filter -->
+                <div class="col-lg-2">
+                    <select class="form-select" @bind="selectedDistance">
+                        <option value="5">Within 5km</option>
+                        <option value="10">Within 10km</option>
+                        <option value="20">Within 20km</option>
+                        <option value="50">Within 50km</option>
+                        <option value="100">Within 100km</option>
+                    </select>
+                </div>
+
+                <!-- Budget Range -->
+                <div class="col-lg-2">
+                    <select class="form-select" @bind="selectedBudget">
+                        <option value="">Any Budget</option>
+                        <option value="0-500">Under $500</option>
+                        <option value="500-1000">$500 - $1,000</option>
+                        <option value="1000-5000">$1,000 - $5,000</option>
+                        <option value="5000+">Over $5,000</option>
+                    </select>
+                </div>
+
+                <!-- Urgency Filter -->
+                <div class="col-lg-2">
+                    <select class="form-select" @bind="selectedUrgency">
+                        <option value="">Any Timeframe</option>
+                        <option value="urgent">Urgent (Today)</option>
+                        <option value="soon">This Week</option>
+                        <option value="flexible">Flexible</option>
+                    </select>
+                </div>
+            </div>
+
+            <!-- Active Filters Display -->
+            @if (HasActiveFilters())
+            {
+                <div class="active-filters mt-3">
+                    <span class="me-2">Active filters:</span>
+                    @if (!string.IsNullOrEmpty(searchTerm))
+                    {
+                        <span class="filter-tag">
+                            @searchTerm
+                            <i class="bi bi-x" @onclick="() => searchTerm = string.Empty"></i>
+                        </span>
+                    }
+                    @if (!string.IsNullOrEmpty(selectedCategory))
+                    {
+                        <span class="filter-tag">
+                            @selectedCategory
+                            <i class="bi bi-x" @onclick="() => selectedCategory = string.Empty"></i>
+                        </span>
+                    }
+                    <button class="btn btn-link btn-sm" @onclick="ClearAllFilters">Clear all</button>
+                </div>
+            }
+        </div>
+    </div>
+
+    <!-- Stats Bar -->
+    <div class="stats-bar">
+        <div class="container">
+            <div class="row">
+                <div class="col-6">
+                    <span class="fw-bold">@filteredJobs.Count jobs</span> matching your criteria
+                </div>
+                <div class="col-6 text-end">
+                    <div class="btn-group" role="group">
+                        <button class="btn btn-sm @(viewMode == "grid" ? "btn-primary" : "btn-outline-primary")" 
+                                @onclick='() => viewMode = "grid"'>
+                            <i class="bi bi-grid-3x3-gap"></i> Grid
+                        </button>
+                        <button class="btn btn-sm @(viewMode == "list" ? "btn-primary" : "btn-outline-primary")" 
+                                @onclick='() => viewMode = "list"'>
+                            <i class="bi bi-list-ul"></i> List
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Jobs Grid/List -->
+    <div class="jobs-content">
+        <div class="container">
+            @if (isLoading)
+            {
+                <div class="text-center py-5">
+                    <div class="spinner-border text-primary" role="status">
+                        <span class="visually-hidden">Loading jobs...</span>
+                    </div>
+                    <p class="mt-3">Loading available jobs...</p>
+                </div>
+            }
+            else if (!filteredJobs.Any())
+            {
+                <div class="no-jobs-found">
+                    <i class="bi bi-inbox" style="font-size: 4rem; color: #dee2e6;"></i>
+                    <h3>No jobs found</h3>
+                    <p>Try adjusting your filters or check back later for new opportunities</p>
+                    <button class="btn btn-primary" @onclick="ClearAllFilters">Clear Filters</button>
+                </div>
+            }
+            else
+            {
+                <div class="@(viewMode == "grid" ? "jobs-grid" : "jobs-list")">
+                    @foreach (var job in filteredJobs)
+                    {
+                        <div class="job-card @(job.IsUrgent ? "urgent" : "")">
+                            @if (job.IsUrgent)
+                            {
+                                <span class="urgency-badge">URGENT</span>
+                            }
+                            
+                            <div class="job-card-header">
+                                <h3 class="job-title">@job.Title</h3>
+                                <span class="job-category badge bg-secondary">@job.Category</span>
+                            </div>
+
+                            <div class="job-card-body">
+                                <p class="job-description">@job.Description</p>
+                                
+                                <div class="job-details">
+                                    <div class="detail-item">
+                                        <i class="bi bi-geo-alt"></i>
+                                        <span>@job.Location (@job.Distance km away)</span>
+                                    </div>
+                                    <div class="detail-item">
+                                        <i class="bi bi-calendar"></i>
+                                        <span>Posted @job.PostedTimeAgo</span>
+                                    </div>
+                                    <div class="detail-item">
+                                        <i class="bi bi-cash-stack"></i>
+                                        <span class="budget">@job.BudgetDisplay</span>
+                                    </div>
+                                    <div class="detail-item">
+                                        <i class="bi bi-clock"></i>
+                                        <span>@job.TimeframeDisplay</span>
+                                    </div>
+                                </div>
+
+                                @if (job.HasPhotos)
+                                {
+                                    <div class="job-photos">
+                                        <i class="bi bi-camera"></i>
+                                        <span>@job.PhotoCount photos attached</span>
+                                    </div>
+                                }
+
+                                <div class="job-stats">
+                                    <span class="stat-item">
+                                        <i class="bi bi-chat-dots"></i> @job.QuotesCount quotes
+                                    </span>
+                                    <span class="stat-item">
+                                        <i class="bi bi-eye"></i> @job.ViewsCount views
+                                    </span>
+                                </div>
+                            </div>
+
+                            <div class="job-card-footer">
+                                <button class="btn btn-outline-primary" @onclick="() => ViewJobDetails(job.Id)">
+                                    <i class="bi bi-info-circle"></i> View Details
+                                </button>
+                                <button class="btn btn-primary" @onclick="() => QuickQuote(job.Id)">
+                                    <i class="bi bi-send"></i> Send Quote
+                                </button>
+                            </div>
+                        </div>
+                    }
+                </div>
+
+                <!-- Pagination -->
+                @if (totalPages > 1)
+                {
+                    <nav aria-label="Jobs pagination" class="mt-4">
+                        <ul class="pagination justify-content-center">
+                            <li class="page-item @(currentPage == 1 ? "disabled" : "")">
+                                <button class="page-link" @onclick="() => ChangePage(currentPage - 1)">Previous</button>
+                            </li>
+                            @for (int i = 1; i <= totalPages; i++)
+                            {
+                                var pageNum = i;
+                                <li class="page-item @(currentPage == pageNum ? "active" : "")">
+                                    <button class="page-link" @onclick="() => ChangePage(pageNum)">@pageNum</button>
+                                </li>
+                            }
+                            <li class="page-item @(currentPage == totalPages ? "disabled" : "")">
+                                <button class="page-link" @onclick="() => ChangePage(currentPage + 1)">Next</button>
+                            </li>
+                        </ul>
+                    </nav>
+                }
+            }
+        </div>
+    </div>
+</div>
+
+@code {
+    private List<JobDto> allJobs = new();
+    private List<JobDto> filteredJobs = new();
+    private bool isLoading = true;
+    private string viewMode = "grid";
+    
+    // Filter properties
+    private string searchTerm = "";
+    private string selectedCategory = "";
+    private string selectedDistance = "20";
+    private string selectedBudget = "";
+    private string selectedUrgency = "";
+    
+    // Pagination
+    private int currentPage = 1;
+    private int pageSize = 12;
+    private int totalPages = 1;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadJobs();
+    }
+
+    private async Task LoadJobs()
+    {
+        isLoading = true;
+        try
+        {
+            // Call your API to get jobs
+            // For now, using mock data
+            allJobs = GetMockJobs();
+            ApplyFilters();
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+
+    private void ApplyFilters()
+    {
+        var query = allJobs.AsQueryable();
+
+        if (!string.IsNullOrEmpty(searchTerm))
+        {
+            query = query.Where(j => j.Title.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ||
+                                    j.Description.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(selectedCategory))
+        {
+            query = query.Where(j => j.Category.Equals(selectedCategory, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(selectedDistance))
+        {
+            var maxDistance = int.Parse(selectedDistance);
+            query = query.Where(j => j.Distance <= maxDistance);
+        }
+
+        // Apply budget filter
+        if (!string.IsNullOrEmpty(selectedBudget))
+        {
+            // Parse budget range and filter
+        }
+
+        if (!string.IsNullOrEmpty(selectedUrgency))
+        {
+            if (selectedUrgency == "urgent")
+                query = query.Where(j => j.IsUrgent);
+        }
+
+        filteredJobs = query.ToList();
+        totalPages = (int)Math.Ceiling(filteredJobs.Count / (double)pageSize);
+    }
+
+    private bool HasActiveFilters()
+    {
+        return !string.IsNullOrEmpty(searchTerm) || 
+               !string.IsNullOrEmpty(selectedCategory) || 
+               !string.IsNullOrEmpty(selectedBudget) || 
+               !string.IsNullOrEmpty(selectedUrgency);
+    }
+
+    private void ClearAllFilters()
+    {
+        searchTerm = "";
+        selectedCategory = "";
+        selectedBudget = "";
+        selectedUrgency = "";
+        ApplyFilters();
+    }
+
+    private void OnSearchChanged(string value)
+    {
+        searchTerm = value;
+        ApplyFilters();
+    }
+
+    private void ViewJobDetails(int jobId)
+    {
+        Navigation.NavigateTo($"/job-details/{jobId}");
+    }
+
+    private void QuickQuote(int jobId)
+    {
+        Navigation.NavigateTo($"/send-quote/{jobId}");
+    }
+
+    private void ChangePage(int page)
+    {
+        if (page >= 1 && page <= totalPages)
+        {
+            currentPage = page;
+        }
+    }
+
+    // Mock data generator
+    private List<JobDto> GetMockJobs()
+    {
+        return new List<JobDto>
+        {
+            new JobDto 
+            { 
+                Id = 1, 
+                Title = "Fix Leaking Bathroom Tap", 
+                Category = "Plumbing",
+                Description = "Bathroom tap has been leaking for a week. Need urgent repair.",
+                Location = "Surry Hills, Sydney",
+                Distance = 5.2,
+                BudgetDisplay = "$200 - $400",
+                TimeframeDisplay = "ASAP",
+                PostedTimeAgo = "2 hours ago",
+                QuotesCount = 3,
+                ViewsCount = 15,
+                IsUrgent = true,
+                HasPhotos = true,
+                PhotoCount = 3
+            },
+            new JobDto 
+            { 
+                Id = 2, 
+                Title = "Install Ceiling Fans in 3 Bedrooms", 
+                Category = "Electrical",
+                Description = "Need 3 ceiling fans installed in bedrooms. Wiring already in place.",
+                Location = "Bondi, Sydney",
+                Distance = 8.7,
+                BudgetDisplay = "$600 - $900",
+                TimeframeDisplay = "This week",
+                PostedTimeAgo = "5 hours ago",
+                QuotesCount = 5,
+                ViewsCount = 22,
+                IsUrgent = false,
+                HasPhotos = false
+            },
+            // Add more mock jobs as needed
+        };
+    }
+
+    // DTO class
+    public class JobDto
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string Category { get; set; }
+        public string Description { get; set; }
+        public string Location { get; set; }
+        public double Distance { get; set; }
+        public string BudgetDisplay { get; set; }
+        public string TimeframeDisplay { get; set; }
+        public string PostedTimeAgo { get; set; }
+        public int QuotesCount { get; set; }
+        public int ViewsCount { get; set; }
+        public bool IsUrgent { get; set; }
+        public bool HasPhotos { get; set; }
+        public int PhotoCount { get; set; }
+    }
+}

--- a/FindTradie.Web/Shared/NavMenu.razor
+++ b/FindTradie.Web/Shared/NavMenu.razor
@@ -17,6 +17,7 @@
             <div class="nav-menu @(collapseNavMenu ? string.Empty : "mobile-open")">
                 <NavLink href="/" class="nav-link" Match="NavLinkMatch.All">Home</NavLink>
                 <NavLink href="/find-tradies" class="nav-link">Find Tradies</NavLink>
+                <NavLink href="/browse-jobs" class="nav-link">Browse Jobs</NavLink>
                 <NavLink href="/how-it-works" class="nav-link">How It Works</NavLink>
                 <NavLink href="/post-job" class="nav-link">Post a Job</NavLink>
                 <NavLink href="/help" class="nav-link">Help Center</NavLink>

--- a/FindTradie.Web/wwwroot/css/site.css
+++ b/FindTradie.Web/wwwroot/css/site.css
@@ -38,6 +38,262 @@ section {
     padding: 0 1rem;
 }
 
+/* Browse Jobs Page Styles */
+.browse-jobs-page {
+    min-height: calc(100vh - 60px);
+    background: #f8f9fa;
+}
+
+.page-header {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    padding: 40px 0;
+}
+
+.page-header h1 {
+    font-size: 2rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+/* Filters Section */
+.filters-section {
+    background: white;
+    padding: 20px 0;
+    border-bottom: 1px solid #dee2e6;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.search-wrapper {
+    position: relative;
+}
+
+.search-icon {
+    position: absolute;
+    left: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #6c757d;
+}
+
+.search-input {
+    padding-left: 38px;
+}
+
+/* Active Filters */
+.active-filters {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.filter-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    background: #e9ecef;
+    border-radius: 20px;
+    font-size: 0.875rem;
+}
+
+.filter-tag i {
+    cursor: pointer;
+    font-size: 1rem;
+}
+
+.filter-tag i:hover {
+    color: #dc3545;
+}
+
+/* Stats Bar */
+.stats-bar {
+    background: white;
+    padding: 15px 0;
+    border-bottom: 1px solid #dee2e6;
+}
+
+/* Jobs Content */
+.jobs-content {
+    padding: 30px 0;
+}
+
+/* Grid View */
+.jobs-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+    gap: 20px;
+}
+
+/* List View */
+.jobs-list {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+
+.jobs-list .job-card {
+    max-width: 100%;
+}
+
+/* Job Card */
+.job-card {
+    background: white;
+    border-radius: 12px;
+    padding: 20px;
+    border: 1px solid #dee2e6;
+    transition: all 0.3s ease;
+    position: relative;
+}
+
+.job-card:hover {
+    box-shadow: 0 6px 20px rgba(0,0,0,0.1);
+    transform: translateY(-2px);
+}
+
+.job-card.urgent {
+    border-left: 4px solid #dc3545;
+}
+
+.urgency-badge {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: #dc3545;
+    color: white;
+    padding: 4px 10px;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.job-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: start;
+    margin-bottom: 15px;
+}
+
+.job-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #2d3748;
+    margin: 0;
+    flex: 1;
+}
+
+.job-category {
+    margin-left: 10px;
+}
+
+.job-description {
+    color: #4a5568;
+    margin-bottom: 15px;
+    line-height: 1.5;
+}
+
+.job-details {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 10px;
+    margin-bottom: 15px;
+}
+
+.detail-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: #718096;
+    font-size: 0.875rem;
+}
+
+.detail-item i {
+    color: #667eea;
+}
+
+.budget {
+    font-weight: 600;
+    color: #2d3748;
+}
+
+.job-photos {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px;
+    background: #f7fafc;
+    border-radius: 6px;
+    margin-bottom: 15px;
+    font-size: 0.875rem;
+    color: #4a5568;
+}
+
+.job-stats {
+    display: flex;
+    gap: 20px;
+    padding: 10px 0;
+    border-top: 1px solid #e2e8f0;
+    border-bottom: 1px solid #e2e8f0;
+    margin-bottom: 15px;
+}
+
+.stat-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: #718096;
+    font-size: 0.875rem;
+}
+
+.job-card-footer {
+    display: flex;
+    gap: 10px;
+}
+
+.job-card-footer button {
+    flex: 1;
+}
+
+/* No Jobs Found */
+.no-jobs-found {
+    text-align: center;
+    padding: 60px 20px;
+}
+
+.no-jobs-found h3 {
+    color: #4a5568;
+    margin: 20px 0 10px;
+}
+
+.no-jobs-found p {
+    color: #718096;
+    margin-bottom: 20px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .jobs-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .job-details {
+        grid-template-columns: 1fr;
+    }
+    
+    .filters-section .row {
+        gap: 10px;
+    }
+    
+    .job-card-footer {
+        flex-direction: column;
+    }
+    
+    .job-card-footer button {
+        width: 100%;
+    }
+}
+
 /* Layout fixes */
 .page {
     min-height: 100vh;


### PR DESCRIPTION
## Summary
- add Browse Jobs page with filtering, search, and job cards
- style Browse Jobs page and tweak nav menu
- link Browse Jobs in navigation

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a069657c60832e9faaabb4c2126911