### PR TITLE
fix: add job service import

### DIFF
--- a/FindTradie.Web/_Imports.razor
+++ b/FindTradie.Web/_Imports.razor
@@ -9,4 +9,5 @@
 @using FindTradie.Web
 @using FindTradie.Web.Shared
 @using FindTradie.Web.Pages
+@using FindTradie.Web.Services
 


### PR DESCRIPTION
## Summary
- ensure Job API service namespace is available in Razor pages

## Testing
- `dotnet build FindTradie.Marketplace.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a06eed91c0832e939c40c38943f115