### PR TITLE
Fix dashboard Browse Jobs link

### DIFF
--- a/FindTradie.Web/Pages/Dashboard.razor
+++ b/FindTradie.Web/Pages/Dashboard.razor
@@ -155,7 +155,7 @@
             <div class="container">
                 <div class="section-header">
                     <h2>New Job Opportunities</h2>
-                    <a href="/jobs/browse" class="btn btn-primary">Browse All Jobs</a>
+                    <a href="/browse-jobs" class="btn btn-primary">Browse All Jobs</a>
                 </div>
 
                 @if (AvailableJobs.Any())


### PR DESCRIPTION
## Summary
- Fix Browse All Jobs button on dashboard to navigate to Browse Jobs page

## Testing
- `dotnet build FindTradie.Marketplace.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a10f532244832eb0f449ad08bfe012