### PR TITLE
Fix navigation links for profile and jobs

### DIFF
--- a/FindTradie.Web/Shared/LoginDisplay.razor
+++ b/FindTradie.Web/Shared/LoginDisplay.razor
@@ -25,8 +25,8 @@
             @if (showMenu)
             {
                 <div class="user-dropdown">
-                    <a href="/profile" class="dropdown-link"><span>👤</span> My Profile</a>
-                    <a href="/my-jobs" class="dropdown-link"><span>📋</span> My Jobs</a>
+                    <a href="/my-profile" @onclick="NavigateToProfile" @onclick:preventDefault="true" class="dropdown-link"><span>👤</span> My Profile</a>
+                    <a href="/my-jobs" @onclick="NavigateToMyJobs" @onclick:preventDefault="true" class="dropdown-link"><span>📋</span> My Jobs</a>
                     <a href="/settings" @onclick="NavigateToSettings" @onclick:preventDefault="true" class="dropdown-link"><span>⚙️</span> Settings</a>
                     <hr class="dropdown-divider" />
                     <button @onclick="LogoutAsync" class="dropdown-link logout"><span>🚪</span> Log Out</button>
@@ -54,6 +54,18 @@
             return string.Empty;
         var parts = UserName.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         return string.Concat(parts.Take(2).Select(p => char.ToUpperInvariant(p[0])));
+    }
+
+    private void NavigateToProfile()
+    {
+        showMenu = false;
+        Navigation.NavigateTo("/my-profile");
+    }
+
+    private void NavigateToMyJobs()
+    {
+        showMenu = false;
+        Navigation.NavigateTo("/my-jobs");
     }
 
     private void NavigateToSettings()


### PR DESCRIPTION
## Summary
- Ensure user dropdown links navigate to profile and jobs pages
- Close user menu and navigate using NavigationManager

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a12da2c730832ea2a3f56efcb086df