### PR TITLE
Add root job and quote routes to Ocelot gateway

### DIFF
--- a/FindTradie.Gateway.API/ocelot.json
+++ b/FindTradie.Gateway.API/ocelot.json
@@ -25,6 +25,18 @@
       "UpstreamHttpMethod": [ "GET", "POST", "PUT", "DELETE", "PATCH" ]
     },
     {
+      "DownstreamPathTemplate": "/api/jobs",
+      "DownstreamScheme": "https",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "localhost",
+          "Port": 7199
+        }
+      ],
+      "UpstreamPathTemplate": "/api/jobs",
+      "UpstreamHttpMethod": [ "GET", "POST", "PUT", "DELETE", "PATCH" ]
+    },
+    {
       "DownstreamPathTemplate": "/api/jobs/{everything}",
       "DownstreamScheme": "https",
       "DownstreamHostAndPorts": [
@@ -34,6 +46,18 @@
         }
       ],
       "UpstreamPathTemplate": "/api/jobs/{everything}",
+      "UpstreamHttpMethod": [ "GET", "POST", "PUT", "DELETE", "PATCH" ]
+    },
+    {
+      "DownstreamPathTemplate": "/api/quotes",
+      "DownstreamScheme": "https",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "localhost",
+          "Port": 7199
+        }
+      ],
+      "UpstreamPathTemplate": "/api/quotes",
       "UpstreamHttpMethod": [ "GET", "POST", "PUT", "DELETE", "PATCH" ]
     },
     {


### PR DESCRIPTION
## Summary
- add explicit `/api/jobs` and `/api/quotes` routes so Ocelot matches root endpoints

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a2cfe7f824832e9903eddc390c60ac