### PR TITLE
Fix job gateway routes to match JobManagement service port

### DIFF
--- a/FindTradie.Gateway.API/ocelot.json
+++ b/FindTradie.Gateway.API/ocelot.json
@@ -30,7 +30,7 @@
       "DownstreamHostAndPorts": [
         {
           "Host": "localhost",
-          "Port": 7199
+          "Port": 7003
         }
       ],
       "UpstreamPathTemplate": "/api/jobs",
@@ -42,7 +42,7 @@
       "DownstreamHostAndPorts": [
         {
           "Host": "localhost",
-          "Port": 7199
+          "Port": 7003
         }
       ],
       "UpstreamPathTemplate": "/api/jobs/{everything}",
@@ -54,7 +54,7 @@
       "DownstreamHostAndPorts": [
         {
           "Host": "localhost",
-          "Port": 7199
+          "Port": 7003
         }
       ],
       "UpstreamPathTemplate": "/api/quotes",
@@ -66,7 +66,7 @@
       "DownstreamHostAndPorts": [
         {
           "Host": "localhost",
-          "Port": 7199
+          "Port": 7003
         }
       ],
       "UpstreamPathTemplate": "/api/quotes/{everything}",


### PR DESCRIPTION
## Summary
- point job and quote routes to JobManagement service's actual port

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d1bc0ac4832e852b3e71af614ffd