### PR TITLE
Handle optional job image URLs in job creation

### DIFF
--- a/FindTradie.Services.JobManagement/DTOs/JobDtos.cs
+++ b/FindTradie.Services.JobManagement/DTOs/JobDtos.cs
@@ -31,7 +31,7 @@ public record CreateJobRequest(
     string? SpecialRequirements,
     bool RequiresLicense,
     bool RequiresInsurance,
-    List<string> ImageUrls
+    List<string>? ImageUrls = null
 );
 
 public record UpdateJobRequest(

--- a/FindTradie.Services.JobManagement/Mappings/JobValidators.cs
+++ b/FindTradie.Services.JobManagement/Mappings/JobValidators.cs
@@ -74,7 +74,8 @@ public class CreateJobRequestValidator : AbstractValidator<CreateJobRequest>
             .When(x => x.PreferredStartDate.HasValue && x.PreferredEndDate.HasValue);
 
         RuleFor(x => x.ImageUrls)
-            .Must(x => x.Count <= 10).WithMessage("Cannot exceed 10 images per job");
+            .Must(x => x == null || x.Count <= 10)
+            .WithMessage("Cannot exceed 10 images per job");
     }
 }
 

--- a/FindTradie.Services.JobManagement/Services/JobService.cs
+++ b/FindTradie.Services.JobManagement/Services/JobService.cs
@@ -65,16 +65,19 @@ public class JobService : IJobService
                 Status = JobStatus.Posted
             };
 
-            // Add images
-            for (int i = 0; i < request.ImageUrls.Count; i++)
+            // Add images if provided
+            if (request.ImageUrls?.Any() == true)
             {
-                job.Images.Add(new JobImage
+                for (int i = 0; i < request.ImageUrls.Count; i++)
                 {
-                    ImageUrl = request.ImageUrls[i],
-                    ImageType = ImageType.Problem,
-                    IsMainImage = i == 0,
-                    DisplayOrder = i + 1
-                });
+                    job.Images.Add(new JobImage
+                    {
+                        ImageUrl = request.ImageUrls[i],
+                        ImageType = ImageType.Problem,
+                        IsMainImage = i == 0,
+                        DisplayOrder = i + 1
+                    });
+                }
             }
 
             // Add status history


### PR DESCRIPTION
## Summary
- Allow jobs to be created without providing image URLs
- Skip image processing when no images are supplied
- Relax image list validation to permit null values

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d819aadc832e846ca08132855848