### PR TITLE
Add JWT auth to API gateway

### DIFF
--- a/FindTradie.Gateway.API/FindTradie.Gateway.API.csproj
+++ b/FindTradie.Gateway.API/FindTradie.Gateway.API.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Ocelot" Version="20.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FindTradie.Gateway.API/appsettings.Development.json
+++ b/FindTradie.Gateway.API/appsettings.Development.json
@@ -4,5 +4,11 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "JWT": {
+    "Secret": "7N0x2b2Jr3o1c5Qn3xA0g1G4yCqY8kVw6i0t3u5y7z2A5b8M1c4N0f6R3s9P2d1L",
+    "Issuer": "FindTradie",
+    "Audience": "FindTradie.Users",
+    "ExpirationInMinutes": 60
   }
 }

--- a/FindTradie.Gateway.API/appsettings.json
+++ b/FindTradie.Gateway.API/appsettings.json
@@ -5,5 +5,11 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "JWT": {
+    "Secret": "7N0x2b2Jr3o1c5Qn3xA0g1G4yCqY8kVw6i0t3u5y7z2A5b8M1c4N0f6R3s9P2d1L",
+    "Issuer": "FindTradie",
+    "Audience": "FindTradie.Users",
+    "ExpirationInMinutes": 60
+  }
 }

--- a/FindTradie.Gateway.API/ocelot.json
+++ b/FindTradie.Gateway.API/ocelot.json
@@ -34,7 +34,11 @@
         }
       ],
       "UpstreamPathTemplate": "/api/jobs",
-      "UpstreamHttpMethod": [ "GET", "POST", "PUT", "DELETE", "PATCH" ]
+      "UpstreamHttpMethod": [ "GET", "POST", "PUT", "DELETE", "PATCH" ],
+      "AuthenticationOptions": {
+        "AuthenticationProviderKey": "JwtBearer",
+        "AllowedScopes": []
+      }
     },
     {
       "DownstreamPathTemplate": "/api/jobs/{everything}",
@@ -46,7 +50,11 @@
         }
       ],
       "UpstreamPathTemplate": "/api/jobs/{everything}",
-      "UpstreamHttpMethod": [ "GET", "POST", "PUT", "DELETE", "PATCH" ]
+      "UpstreamHttpMethod": [ "GET", "POST", "PUT", "DELETE", "PATCH" ],
+      "AuthenticationOptions": {
+        "AuthenticationProviderKey": "JwtBearer",
+        "AllowedScopes": []
+      }
     },
     {
       "DownstreamPathTemplate": "/api/quotes",


### PR DESCRIPTION
## Summary
- secure gateway with JWT bearer authentication
- configure job routes to require authentication
- add JWT settings and package reference

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e785e870832eb4f33a076704acd3