### PR TITLE
Register JwtBearer scheme for Ocelot

### DIFF
--- a/FindTradie.Gateway.API/Program.cs
+++ b/FindTradie.Gateway.API/Program.cs
@@ -24,8 +24,12 @@ builder.Services.AddCors(options =>
 var jwtSecret = builder.Configuration["JWT:Secret"];
 if (!string.IsNullOrEmpty(jwtSecret))
 {
-    builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-        .AddJwtBearer(options =>
+    builder.Services.AddAuthentication(options =>
+    {
+        options.DefaultAuthenticateScheme = "JwtBearer";
+        options.DefaultChallengeScheme = "JwtBearer";
+    })
+        .AddJwtBearer("JwtBearer", options =>
         {
             options.TokenValidationParameters = new TokenValidationParameters
             {


### PR DESCRIPTION
## Summary
- align JWT auth scheme with Ocelot's `AuthenticationProviderKey` by registering a `JwtBearer` scheme and setting it as default

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f0e96410832e95f6a6bb7fbc1edb