### PR TITLE
Enable customers to view posted jobs and tradies to browse listings

### DIFF
--- a/FindTradie.Web/Pages/BrowseJobs.razor
+++ b/FindTradie.Web/Pages/BrowseJobs.razor
@@ -1,5 +1,9 @@
 ﻿@page "/browse-jobs"
+@attribute [Authorize(Roles = "Tradie,ServiceProvider")]
 @using FindTradie.Web.Services
+@using FindTradie.Services.JobManagement.DTOs
+@using FindTradie.Shared.Domain.Enums
+@using System.Linq
 @inject IJobApiService JobService
 @inject NavigationManager Navigation
 @inject AuthenticationStateProvider AuthStateProvider
@@ -218,44 +222,31 @@
         isLoading = true;
         try
         {
-            // Mock data for demonstration
-            allJobs = new List<JobDto>
+            var response = await JobService.SearchJobsAsync(new JobSearchRequest());
+            if (response.Success && response.Data != null)
             {
-                new JobDto
+                allJobs = response.Data.Select(dto => new JobDto
                 {
-                    Id = Guid.NewGuid(),
-                    Title = "Fix Leaking Bathroom Tap",
-                    Category = "Plumbing",
-                    Description = "Bathroom tap has been leaking for a week. Need urgent repair.",
-                    Location = "Surry Hills, Sydney",
-                    Distance = 5.2,
-                    BudgetMin = 200,
-                    BudgetMax = 400,
-                    PostedTime = "2 hours ago",
-                    Timeframe = "ASAP",
-                    IsUrgent = true,
-                    PhotoCount = 3,
-                    QuoteCount = 3,
-                    ViewCount = 15
-                },
-                new JobDto
-                {
-                    Id = Guid.NewGuid(),
-                    Title = "Install Ceiling Fans in 3 Bedrooms",
-                    Category = "Electrical",
-                    Description = "Need 3 ceiling fans installed in bedrooms. Wiring already in place.",
-                    Location = "Bondi, Sydney",
-                    Distance = 8.7,
-                    BudgetMin = 600,
-                    BudgetMax = 900,
-                    PostedTime = "5 hours ago",
-                    Timeframe = "This week",
-                    IsUrgent = false,
-                    PhotoCount = 0,
-                    QuoteCount = 5,
-                    ViewCount = 22
-                }
-            };
+                    Id = dto.Id,
+                    Title = dto.Title,
+                    Category = dto.Category.ToString(),
+                    Description = dto.Description,
+                    Location = $"{dto.Suburb}, {dto.State}",
+                    Distance = dto.DistanceKm,
+                    BudgetMin = dto.BudgetMin ?? 0,
+                    BudgetMax = dto.BudgetMax ?? 0,
+                    PostedTime = dto.CreatedAt.ToString("dd MMM yyyy"),
+                    Timeframe = dto.PreferredStartDate?.ToString("dd MMM") ?? "Flexible",
+                    IsUrgent = dto.Urgency != JobUrgency.Normal,
+                    PhotoCount = dto.HasImages ? 1 : 0,
+                    QuoteCount = dto.QuoteCount,
+                    ViewCount = 0
+                }).ToList();
+            }
+            else
+            {
+                allJobs = new List<JobDto>();
+            }
 
             ApplyFilters();
         }

--- a/FindTradie.Web/Pages/Myjobs.razor
+++ b/FindTradie.Web/Pages/Myjobs.razor
@@ -417,8 +417,9 @@
             UserName = user.FindFirst("FirstName")?.Value ??
                       user.Identity?.Name ?? "User";
 
-            IsCustomer = user.IsInRole("Customer");
             IsTradie = user.IsInRole("Tradie") || user.IsInRole("ServiceProvider");
+            // Treat any non-tradie as customer so regular users can view their jobs
+            IsCustomer = user.IsInRole("Customer") || !IsTradie;
 
             var userIdClaim = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
             if (Guid.TryParse(userIdClaim, out var id))
@@ -446,22 +447,7 @@
             return;
         }
 
-        if (IsCustomer)
-        {
-            ActiveJobs.Clear();
-            CompletedJobs.Clear();
-            CancelledJobs.Clear();
-
-            var response = await JobService.GetCustomerJobsAsync(UserId);
-            if (response.Success && response.Data != null)
-            {
-                var jobs = response.Data.Select(MapCustomerJob).ToList();
-                ActiveJobs = jobs.Where(j => j.Status != JobStatus.Completed && j.Status != JobStatus.Cancelled).ToList();
-                CompletedJobs = jobs.Where(j => j.Status == JobStatus.Completed).ToList();
-                CancelledJobs = jobs.Where(j => j.Status == JobStatus.Cancelled).ToList();
-            }
-        }
-        else
+        if (IsTradie)
         {
             AssignedJobs.Clear();
 
@@ -475,6 +461,21 @@
                     Address = $"{dto.Suburb}, {dto.State}",
                     AcceptedAmount = dto.BudgetMax ?? 0,
                 }).ToList();
+            }
+        }
+        else
+        {
+            ActiveJobs.Clear();
+            CompletedJobs.Clear();
+            CancelledJobs.Clear();
+
+            var response = await JobService.GetCustomerJobsAsync(UserId);
+            if (response.Success && response.Data != null)
+            {
+                var jobs = response.Data.Select(MapCustomerJob).ToList();
+                ActiveJobs = jobs.Where(j => j.Status != JobStatus.Completed && j.Status != JobStatus.Cancelled).ToList();
+                CompletedJobs = jobs.Where(j => j.Status == JobStatus.Completed).ToList();
+                CancelledJobs = jobs.Where(j => j.Status == JobStatus.Cancelled).ToList();
             }
         }
     }

--- a/FindTradie.Web/Services/JobApiService.cs
+++ b/FindTradie.Web/Services/JobApiService.cs
@@ -139,6 +139,7 @@ public class JobApiService : IJobApiService
     {
         try
         {
+            await SetAuthorizationHeaderAsync();
             var json = JsonSerializer.Serialize(request);
             var content = new StringContent(json, Encoding.UTF8, "application/json");
 


### PR DESCRIPTION
## Summary
- Treat any non-tradie user as a customer and load their own jobs
- Add auth header when searching jobs
- Replace mock job browsing with API-driven search for tradies

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f23487d0832e999ac60609d56074