### PR TITLE
fix: allow AutoMapper to create JobSummaryDto

### DIFF
--- a/FindTradie.Services.JobManagement/DTOs/JobDtos.cs
+++ b/FindTradie.Services.JobManagement/DTOs/JobDtos.cs
@@ -45,24 +45,25 @@ public record UpdateJobRequest(
     string? SpecialRequirements
 );
 
-public record JobSummaryDto(
-    Guid Id,
-    string Title,
-    string Description,
-    ServiceCategory Category,
-    string SubCategory,
-    JobUrgency Urgency,
-    JobStatus Status,
-    decimal? BudgetMin,
-    decimal? BudgetMax,
-    string Suburb,
-    string State,
-    double DistanceKm,
-    DateTime CreatedAt,
-    int QuoteCount,
-    bool HasImages,
-    DateTime? PreferredStartDate
-);
+public record JobSummaryDto
+{
+    public Guid Id { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string Description { get; init; } = string.Empty;
+    public ServiceCategory Category { get; init; }
+    public string SubCategory { get; init; } = string.Empty;
+    public JobUrgency Urgency { get; init; }
+    public JobStatus Status { get; init; }
+    public decimal? BudgetMin { get; init; }
+    public decimal? BudgetMax { get; init; }
+    public string Suburb { get; init; } = string.Empty;
+    public string State { get; init; } = string.Empty;
+    public double DistanceKm { get; init; }
+    public DateTime CreatedAt { get; init; }
+    public int QuoteCount { get; init; }
+    public bool HasImages { get; init; }
+    public DateTime? PreferredStartDate { get; init; }
+}
 
 public record JobDetailDto
 {

--- a/FindTradie.Services.JobManagement/Repositories/JobRepository.cs
+++ b/FindTradie.Services.JobManagement/Repositories/JobRepository.cs
@@ -84,26 +84,27 @@ public class JobRepository : IJobRepository
         query = query.Where(j => j.Status == JobStatus.Posted || j.Status == JobStatus.QuoteRequested);
 
         var jobs = await query
-            .Select(j => new JobSummaryDto(
-                j.Id,
-                j.Title,
-                j.Description.Length > 200 ? j.Description.Substring(0, 200) + "..." : j.Description,
-                j.Category,
-                j.SubCategory,
-                j.Urgency,
-                j.Status,
-                j.BudgetMin,
-                j.BudgetMax,
-                j.Suburb,
-                j.State,
-                request.Latitude.HasValue && request.Longitude.HasValue
+            .Select(j => new JobSummaryDto
+            {
+                Id = j.Id,
+                Title = j.Title,
+                Description = j.Description.Length > 200 ? j.Description.Substring(0, 200) + "..." : j.Description,
+                Category = j.Category,
+                SubCategory = j.SubCategory,
+                Urgency = j.Urgency,
+                Status = j.Status,
+                BudgetMin = j.BudgetMin,
+                BudgetMax = j.BudgetMax,
+                Suburb = j.Suburb,
+                State = j.State,
+                DistanceKm = request.Latitude.HasValue && request.Longitude.HasValue
                     ? CalculateDistance(request.Latitude.Value, request.Longitude.Value, j.Latitude, j.Longitude)
                     : 0,
-                j.CreatedAt,
-                j.Quotes.Count(q => !q.IsDeleted),
-                j.Images.Any(),
-                j.PreferredStartDate
-            ))
+                CreatedAt = j.CreatedAt,
+                QuoteCount = j.Quotes.Count(q => !q.IsDeleted),
+                HasImages = j.Images.Any(),
+                PreferredStartDate = j.PreferredStartDate
+            })
             .Where(j => !request.RadiusKm.HasValue || j.DistanceKm <= request.RadiusKm.Value)
             .OrderBy(j => j.CreatedAt)
             .Skip((request.PageNumber - 1) * request.PageSize)


### PR DESCRIPTION
## Summary
- redefine JobSummaryDto with parameterless constructor and init-only properties
- map job search results using property initializer instead of positional record

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f828e104832e95b0c81ba7e82c90