### PR TITLE
fix: include auth header when fetching job details

### DIFF
--- a/FindTradie.Web/Services/JobApiService.cs
+++ b/FindTradie.Web/Services/JobApiService.cs
@@ -95,6 +95,7 @@ public class JobApiService : IJobApiService
     {
         try
         {
+            await SetAuthorizationHeaderAsync();
             var response = await _httpClient.GetAsync($"/api/jobs/{id}");
 
             return await HandleResponse<JobDetailDto>(response);


### PR DESCRIPTION
## Summary
- send auth token when retrieving job details so tradies can view assigned jobs

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a305e1bb48832e9e89536f46e5b776