### PR TITLE
fix: accept sub claim for tradie job listing

### DIFF
--- a/FindTradie.Services.JobManagement/Controllers/JobsController.cs
+++ b/FindTradie.Services.JobManagement/Controllers/JobsController.cs
@@ -9,6 +9,7 @@ using FindTradie.Shared.Domain.Enums;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System;
+using System.IdentityModel.Tokens.Jwt;
 
 namespace FindTradie.Services.JobManagement.Controllers;
 
@@ -94,7 +95,9 @@ public class JobsController : ControllerBase
         [FromQuery] int pageNumber = 1,
         [FromQuery] int pageSize = 20)
     {
-        var tradieIdClaim = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        var tradieIdClaim = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+            ?? User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+
         if (!Guid.TryParse(tradieIdClaim, out var tradieId))
         {
             return Unauthorized(ApiResponse<List<JobSummaryDto>>.ErrorResult("Invalid user identifier"));

--- a/FindTradie.Web/Services/JobApiService.cs
+++ b/FindTradie.Web/Services/JobApiService.cs
@@ -95,6 +95,7 @@ public class JobApiService : IJobApiService
     {
         try
         {
+            await SetAuthorizationHeaderAsync();
             var response = await _httpClient.GetAsync($"/api/jobs/{id}");
 
             return await HandleResponse<JobDetailDto>(response);


### PR DESCRIPTION
## Summary
- allow job service to read tradie id from `sub` claim as fallback when listing tradie jobs

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a305e1bb48832e9e89536f46e5b776