### PR TITLE
Add TradieOnly authorization policy

### DIFF
--- a/FindTradie.Web/Program.cs
+++ b/FindTradie.Web/Program.cs
@@ -4,6 +4,7 @@ using FindTradie.Web.Services;
 using FindTradie.Web.Auth;
 using Microsoft.AspNetCore.Components.Authorization;
 using Blazored.LocalStorage;
+using FindTradie.Shared.Domain.Enums;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -32,7 +33,11 @@ builder.Services.AddScoped<ITradieApiService, TradieApiService>();
 builder.Services.AddScoped<IJobApiService, JobApiService>();
 builder.Services.AddScoped<IQuoteApiService, QuoteApiService>();
 // Add Authorization
-builder.Services.AddAuthorizationCore();
+builder.Services.AddAuthorizationCore(options =>
+{
+    options.AddPolicy("TradieOnly", policy =>
+        policy.RequireClaim("UserType", nameof(UserType.Tradie)));
+});
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- Define TradieOnly authorization policy based on UserType claim
- Register policy during service configuration

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c1e53d24832ebe8a5993b81618a4