### PR TITLE
Fix DTO namespace imports in EditJob page

### DIFF
--- a/FindTradie.Web/Pages/EditJob.razor
+++ b/FindTradie.Web/Pages/EditJob.razor
@@ -2,6 +2,7 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Authorization
 @using FindTradie.Shared.Domain.Enums
+@using FindTradie.Services.JobManagement.DTOs
 @using System.ComponentModel.DataAnnotations
 @attribute [Authorize(Roles = "Customer")]
 @inject NavigationManager Navigation


### PR DESCRIPTION
## Summary
- import job management DTOs for EditJob page

## Testing
- `dotnet build FindTradie.Marketplace.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a666d5075c832e802f51176ffb4684