### PR TITLE
Fix user claim retrieval for job editing

### DIFF
--- a/FindTradie.Web/Pages/EditJob.razor
+++ b/FindTradie.Web/Pages/EditJob.razor
@@ -4,6 +4,7 @@
 @using FindTradie.Shared.Domain.Enums
 @using FindTradie.Services.JobManagement.DTOs
 @using System.ComponentModel.DataAnnotations
+@using System.Security.Claims
 @attribute [Authorize(Roles = "Customer")]
 @inject NavigationManager Navigation
 @inject IJSRuntime JSRuntime
@@ -342,7 +343,8 @@
 
             // Get the current user
             var authState = await AuthStateProvider.GetAuthenticationStateAsync();
-            var userId = authState.User.FindFirst("UserId")?.Value;
+            var userId = authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                         ?? authState.User.FindFirst("UserId")?.Value;
 
             if (string.IsNullOrEmpty(userId))
             {


### PR DESCRIPTION
## Summary
- ensure Edit Job page reads user ID from ClaimTypes.NameIdentifier to stop login redirect
- add missing System.Security.Claims import

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a66a5a5684832ebf3f6750ed241058