### PR TITLE
Ensure UpdateJobRequest handles image updates

### DIFF
--- a/FindTradie.Services.JobManagement/DTOs/JobDtos.cs
+++ b/FindTradie.Services.JobManagement/DTOs/JobDtos.cs
@@ -49,8 +49,12 @@ public record UpdateJobRequest
     public DateTime? PreferredEndDate { get; init; }
     public bool IsFlexibleTiming { get; init; }
     public string? SpecialRequirements { get; init; }
-    public List<string>? ImageUrls { get; init; }
-    public List<Guid>? RemovedImageIds { get; init; }
+    // Optional collection of newly added image URLs. Defaults to an empty list
+    // so callers can add images without worrying about null checks.
+    public List<string>? ImageUrls { get; init; } = new();
+    // Optional collection of image identifiers to remove from the job.
+    // Initialised to an empty list to simplify consumer logic.
+    public List<Guid>? RemovedImageIds { get; init; } = new();
 }
 
 public record JobSummaryDto


### PR DESCRIPTION
## Summary
- Initialize ImageUrls and RemovedImageIds in UpdateJobRequest to empty lists
- Document purpose of image collection fields for job updates

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a674753794832ea3c2b9325f826ed9