### PR TITLE
Allow partial job updates

### DIFF
--- a/FindTradie.Services.JobManagement/DTOs/JobDtos.cs
+++ b/FindTradie.Services.JobManagement/DTOs/JobDtos.cs
@@ -36,18 +36,18 @@ public record CreateJobRequest(
 
 public record UpdateJobRequest
 {
-    public string Title { get; init; } = string.Empty;
-    public string Description { get; init; } = string.Empty;
-    public ServiceCategory Category { get; init; }
-    public JobUrgency Urgency { get; init; }
-    public string Suburb { get; init; } = string.Empty;
-    public string PostCode { get; init; } = string.Empty;
-    public string Address { get; init; } = string.Empty;
+    public string? Title { get; init; }
+    public string? Description { get; init; }
+    public ServiceCategory? Category { get; init; }
+    public JobUrgency? Urgency { get; init; }
+    public string? Suburb { get; init; }
+    public string? PostCode { get; init; }
+    public string? Address { get; init; }
     public decimal? BudgetMin { get; init; }
     public decimal? BudgetMax { get; init; }
     public DateTime? PreferredStartDate { get; init; }
     public DateTime? PreferredEndDate { get; init; }
-    public bool IsFlexibleTiming { get; init; }
+    public bool? IsFlexibleTiming { get; init; }
     public string? SpecialRequirements { get; init; }
     // Optional collection of newly added image URLs. Defaults to an empty list
     // so callers can add images without worrying about null checks.

--- a/FindTradie.Services.JobManagement/Services/JobService.cs
+++ b/FindTradie.Services.JobManagement/Services/JobService.cs
@@ -138,20 +138,20 @@ public class JobService : IJobService
                 return ApiResponse<JobDetailDto>.ErrorResult("Job cannot be updated in its current status");
             }
 
-            // Update job properties
-            job.Title = request.Title;
-            job.Description = request.Description;
-            job.Category = request.Category;
-            job.Urgency = request.Urgency;
-            job.Suburb = request.Suburb;
-            job.PostCode = request.PostCode;
-            job.Address = request.Address;
-            job.BudgetMin = request.BudgetMin;
-            job.BudgetMax = request.BudgetMax;
-            job.PreferredStartDate = request.PreferredStartDate;
-            job.PreferredEndDate = request.PreferredEndDate;
-            job.IsFlexibleTiming = request.IsFlexibleTiming;
-            job.SpecialRequirements = request.SpecialRequirements;
+            // Update job properties only when values are provided
+            job.Title = request.Title ?? job.Title;
+            job.Description = request.Description ?? job.Description;
+            job.Category = request.Category ?? job.Category;
+            job.Urgency = request.Urgency ?? job.Urgency;
+            job.Suburb = request.Suburb ?? job.Suburb;
+            job.PostCode = request.PostCode ?? job.PostCode;
+            job.Address = request.Address ?? job.Address;
+            job.BudgetMin = request.BudgetMin ?? job.BudgetMin;
+            job.BudgetMax = request.BudgetMax ?? job.BudgetMax;
+            job.PreferredStartDate = request.PreferredStartDate ?? job.PreferredStartDate;
+            job.PreferredEndDate = request.PreferredEndDate ?? job.PreferredEndDate;
+            job.IsFlexibleTiming = request.IsFlexibleTiming ?? job.IsFlexibleTiming;
+            job.SpecialRequirements = request.SpecialRequirements ?? job.SpecialRequirements;
 
             // Remove images
             if (request.RemovedImageIds?.Any() == true)


### PR DESCRIPTION
## Summary
- make `UpdateJobRequest` fields nullable so missing properties don't trigger model validation
- update job service to only overwrite job fields when new values are supplied

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a67833686c832eae1e15a812f9220c