### PR TITLE
Allow longer job image URLs

### DIFF
--- a/FindTradie.Services.JobManagement/Data/JobDbContext.cs
+++ b/FindTradie.Services.JobManagement/Data/JobDbContext.cs
@@ -133,7 +133,9 @@ public class JobDbContext : DbContext
         modelBuilder.Entity<JobImage>(entity =>
         {
             entity.HasKey(e => e.Id);
-            entity.Property(e => e.ImageUrl).IsRequired().HasMaxLength(500);
+            entity.Property(e => e.ImageUrl)
+                  .IsRequired()
+                  .HasColumnType("nvarchar(max)");
             entity.Property(e => e.Caption).HasMaxLength(200);
             entity.Property(e => e.Description).HasMaxLength(500);
 

--- a/FindTradie.Services.JobManagement/Data/Migrations/20250815023000_IncreaseJobImageUrlLength.cs
+++ b/FindTradie.Services.JobManagement/Data/Migrations/20250815023000_IncreaseJobImageUrlLength.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FindTradie.Services.JobManagement.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class IncreaseJobImageUrlLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ImageUrl",
+                table: "JobImages",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(500)",
+                oldMaxLength: 500);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ImageUrl",
+                table: "JobImages",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+    }
+}
+

--- a/FindTradie.Services.JobManagement/Data/Migrations/JobDbContextModelSnapshot.cs
+++ b/FindTradie.Services.JobManagement/Data/Migrations/JobDbContextModelSnapshot.cs
@@ -215,8 +215,7 @@ namespace FindTradie.Services.JobManagement.Data.Migrations
 
                     b.Property<string>("ImageUrl")
                         .IsRequired()
-                        .HasMaxLength(500)
-                        .HasColumnType("nvarchar(500)");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");


### PR DESCRIPTION
## Summary
- Remove 500 character limit on job image URLs
- Add EF migration to expand JobImages.ImageUrl column

## Testing
- `dotnet build FindTradie.Services.JobManagement/FindTradie.Services.JobManagement.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6798b1b60832e95d732160fb96a5a