### PR TITLE
fix: avoid EF concurrency errors when adding child entities

### DIFF
--- a/FindTradie.Services.JobManagement/Repositories/JobRepository.cs
+++ b/FindTradie.Services.JobManagement/Repositories/JobRepository.cs
@@ -165,7 +165,14 @@ public class JobRepository : IJobRepository
 
     public async Task<Job> UpdateAsync(Job job)
     {
-        _context.Jobs.Update(job);
+        // The job is already being tracked by the context when retrieved through
+        // repository methods such as GetByIdWithDetailsAsync. Calling Update on
+        // the tracked entity forces EF Core to mark the entire object graph as
+        // modified, which causes new child entities (e.g. newly uploaded images)
+        // to be treated as updates rather than inserts. This results in a
+        // DbUpdateConcurrencyException when EF attempts to update rows that do
+        // not yet exist. Simply saving the context will persist any changes and
+        // correctly insert new child records.
         await _context.SaveChangesAsync();
         return job;
     }

--- a/FindTradie.Services.JobManagement/Repositories/QuoteRepository.cs
+++ b/FindTradie.Services.JobManagement/Repositories/QuoteRepository.cs
@@ -60,7 +60,11 @@ public class QuoteRepository : IQuoteRepository
 
     public async Task<Quote> UpdateAsync(Quote quote)
     {
-        _context.Quotes.Update(quote);
+        // Similar to jobs, quotes and their related items are tracked by the
+        // context. Using Update would mark new child entities as modified and
+        // lead to failed updates for non-existent rows. Saving changes directly
+        // ensures EF Core inserts new records and updates existing ones
+        // appropriately.
         await _context.SaveChangesAsync();
         return quote;
     }


### PR DESCRIPTION
## Summary
- prevent EF Core from marking tracked Job and Quote graphs as modified
- rely on SaveChanges to insert new JobImage and QuoteItem entities without concurrency issues

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a67c752274832e873efed1b110e13c