### PR TITLE
Fix job image removal to avoid concurrency issues

### DIFF
--- a/FindTradie.Services.JobManagement/Services/JobService.cs
+++ b/FindTradie.Services.JobManagement/Services/JobService.cs
@@ -159,7 +159,14 @@ public class JobService : IJobService
             // Remove images
             if (request.RemovedImageIds?.Any() == true)
             {
-                job.Images.RemoveAll(img => request.RemovedImageIds.Contains(img.Id));
+                var imagesToRemove = job.Images
+                    .Where(img => request.RemovedImageIds.Contains(img.Id))
+                    .ToList();
+
+                foreach (var image in imagesToRemove)
+                {
+                    job.Images.Remove(image);
+                }
             }
 
             // Add new images


### PR DESCRIPTION
## Summary
- remove job images individually so EF tracks deletions properly

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a7969290832ea0e29dd5d43c1d9d