### PR TITLE
Fix job image persistence and mapping

### DIFF
--- a/FindTradie.Services.JobManagement/DTOs/JobDtos.cs
+++ b/FindTradie.Services.JobManagement/DTOs/JobDtos.cs
@@ -116,15 +116,18 @@ public record JobDetailDto
     public List<JobMessageDto> RecentMessages { get; init; } = new();
 }
 
-public record JobImageDto(
-    Guid Id,
-    string ImageUrl,
-    string? Caption,
-    string? Description,
-    ImageType ImageType,
-    bool IsMainImage,
-    int DisplayOrder
-);
+public class JobImageDto
+{
+    public Guid Id { get; set; }
+    public string ImageUrl { get; set; } = string.Empty;
+    public string? Caption { get; set; }
+    public string? Description { get; set; }
+    public int DisplayOrder { get; set; }
+    public ImageType ImageType { get; set; }
+    public bool IsMainImage { get; set; }
+    public bool IsDeleted { get; set; }
+    public DateTime CreatedAt { get; set; }
+}
 
 public record QuoteSummaryDto(
     Guid Id,

--- a/FindTradie.Services.JobManagement/Entities/Job.cs
+++ b/FindTradie.Services.JobManagement/Entities/Job.cs
@@ -110,15 +110,13 @@ public class QuoteItem : BaseEntity
 public class JobImage : BaseEntity
 {
     public Guid JobId { get; set; }
+    public Job Job { get; set; } = null!;
     public string ImageUrl { get; set; } = string.Empty;
     public string? Caption { get; set; }
     public string? Description { get; set; }
+    public int DisplayOrder { get; set; }
     public ImageType ImageType { get; set; } = ImageType.Problem;
     public bool IsMainImage { get; set; } = false;
-    public int DisplayOrder { get; set; }
-
-    // Navigation
-    public Job Job { get; set; } = null!;
 }
 
 public class JobMessage : BaseEntity

--- a/FindTradie.Services.JobManagement/Repositories/IJobRepository.cs
+++ b/FindTradie.Services.JobManagement/Repositories/IJobRepository.cs
@@ -20,6 +20,7 @@ public interface IJobRepository
     Task<List<Job>> GetJobsByTradieAsync(Guid tradieId, int pageNumber = 1, int pageSize = 20);
     Task<Job> CreateAsync(Job job);
     Task<Job> UpdateAsync(Job job);
+    Task<Job> UpdateTrackedAsync(Guid id, Action<Job> updateAction);
     Task<bool> ExistsAsync(Guid id);
     Task<int> GetActiveJobsCountByCustomerAsync(Guid customerId);
     Task<List<Job>> GetJobsNeedingAttentionAsync();

--- a/FindTradie.Services.JobManagement/Repositories/JobRepository.cs
+++ b/FindTradie.Services.JobManagement/Repositories/JobRepository.cs
@@ -168,6 +168,23 @@ public class JobRepository : IJobRepository
         return job;
     }
 
+    public async Task<Job> UpdateTrackedAsync(Guid id, Action<Job> updateAction)
+    {
+        var job = await _context.Jobs
+            .Include(j => j.Images)
+            .Include(j => j.StatusHistory)
+            .FirstOrDefaultAsync(j => j.Id == id);
+
+        if (job == null)
+            throw new ArgumentException($"Job with ID {id} not found");
+
+        updateAction(job);
+
+        await _context.SaveChangesAsync();
+
+        return job;
+    }
+
     public async Task<Job> UpdateAsync(Job job)
     {
         // The job should already be tracked when retrieved via repository methods

--- a/FindTradie.Web/Pages/EditJob.razor
+++ b/FindTradie.Web/Pages/EditJob.razor
@@ -202,7 +202,7 @@
                                             {
                                                 <div class="photo-item">
                                                     <img src="@image.Url" alt="Job photo" class="img-thumbnail" />
-                                                    @if (job.Status == JobStatus.Posted)
+                                                    @if (job.Status == JobStatus.Posted || job.Status == JobStatus.QuoteRequested)
                                                     {
                                                         <button type="button" class="btn btn-sm btn-danger photo-remove"
                                                                 @onclick="() => RemovePhoto(image.Id)">
@@ -215,7 +215,7 @@
                                     </div>
                                 }
 
-                                @if (job.Status == JobStatus.Posted)
+                                @if (job.Status == JobStatus.Posted || job.Status == JobStatus.QuoteRequested)
                                 {
                                     <div class="mb-3">
                                         <label for="photos" class="form-label">Add More Photos</label>
@@ -385,28 +385,31 @@
     private JobEditModel MapToEditModel(JobDetailDto dto)
     {
         return new JobEditModel
-            {
-                Id = dto.Id,
-                Title = dto.Title,
-                Description = dto.Description,
-                Category = dto.Category,
-                Urgency = dto.Urgency,
-                Status = dto.Status,
-                Suburb = dto.Suburb,
-                Postcode = dto.PostCode,
-                AddressDetails = dto.Address,
-                BudgetMin = dto.BudgetMin,
-                BudgetMax = dto.BudgetMax,
-                PreferredStartDate = dto.PreferredStartDate,
-                FlexibleOnDates = dto.IsFlexibleTiming,
-                Images = dto.Images?.Select(img => new ImageModel
+        {
+            Id = dto.Id,
+            Title = dto.Title,
+            Description = dto.Description,
+            Category = dto.Category,
+            Urgency = dto.Urgency,
+            Status = dto.Status,
+            Suburb = dto.Suburb,
+            Postcode = dto.PostCode,
+            AddressDetails = dto.Address,
+            BudgetMin = dto.BudgetMin,
+            BudgetMax = dto.BudgetMax,
+            PreferredStartDate = dto.PreferredStartDate,
+            FlexibleOnDates = dto.IsFlexibleTiming,
+            Images = dto.Images?
+                .Where(img => !img.IsDeleted)
+                .Select(img => new ImageModel
                 {
                     Id = img.Id,
                     Url = img.ImageUrl
                 }).ToList() ?? new List<ImageModel>(),
-                QuotesCount = dto.Quotes?.Count ?? 0,
-                CreatedAt = dto.CreatedAt
-            };
+            QuotesCount = dto.Quotes?.Count ?? 0,
+            ViewsCount = 0,
+            CreatedAt = dto.CreatedAt
+        };
     }
 
     private async Task HandleValidSubmit()
@@ -568,6 +571,7 @@
 
         public List<ImageModel> Images { get; set; } = new();
         public int QuotesCount { get; set; }
+        public int ViewsCount { get; set; }
         public DateTime CreatedAt { get; set; }
     }
 


### PR DESCRIPTION
## Summary
- add tracked update path for jobs with images
- map `JobImage` URLs correctly and expose full metadata
- refine edit job page to filter deleted images and allow soft deletes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b5cc66cc832eab63e2c1474720bf