### PR TITLE
Embed Google Maps previews on job details pages and show remove icon

### DIFF
--- a/FindTradie.Web/Pages/EditJob.razor
+++ b/FindTradie.Web/Pages/EditJob.razor
@@ -214,7 +214,7 @@
                                                     {
                                                         <button type="button" class="photo-remove"
                                                                 @onclick="() => RemovePhoto(image.Id)">
-                                                            <i class="bi bi-x-lg"></i>
+                                                            <i class="fas fa-times"></i>
                                                         </button>
                                                     }
                                                 </div>
@@ -243,7 +243,7 @@
                                                     <img src="@photo.Preview" alt="New photo" class="img-thumbnail" />
                                                     <button type="button" class="photo-remove"
                                                             @onclick="() => RemoveNewPhoto(photo)">
-                                                        <i class="bi bi-x-lg"></i>
+                                                        <i class="fas fa-times"></i>
                                                     </button>
                                                 </div>
                                             }

--- a/FindTradie.Web/Pages/JobDetails.razor
+++ b/FindTradie.Web/Pages/JobDetails.razor
@@ -220,11 +220,9 @@
                                 <span class="distance">@job.Distance km from you</span>
                             </div>
                             <div class="map-preview">
-                                <!-- Map would go here -->
-                                <div class="map-placeholder">
-                                    <i class="icon-map"></i>
-                                    <span>Map View</span>
-                                </div>
+                                <iframe loading="lazy" allowfullscreen
+                                        src="@($"https://www.google.com/maps?q={GetMapQuery()}&output=embed")">
+                                </iframe>
                             </div>
                         </div>
                     </div>
@@ -420,6 +418,11 @@
     {
         // Implement report functionality
         await Task.CompletedTask;
+    }
+
+    private string GetMapQuery()
+    {
+        return Uri.EscapeDataString(job?.Suburb ?? string.Empty);
     }
 
     // DTOs

--- a/FindTradie.Web/Pages/UserJobDetails.razor
+++ b/FindTradie.Web/Pages/UserJobDetails.razor
@@ -138,10 +138,9 @@
                             @if (job.IsLocationVisible)
                             {
                                 <div class="map-container">
-                                    <div class="map-placeholder">
-                                        <i class="fas fa-map"></i>
-                                        <span>Map View</span>
-                                    </div>
+                                    <iframe loading="lazy" allowfullscreen
+                                            src="@($"https://www.google.com/maps?q={GetMapQuery()}&output=embed")">
+                                    </iframe>
                                 </div>
                             }
                         </div>
@@ -404,6 +403,11 @@
     private void MarkComplete() { /* TODO */ }
     private void CancelJob() { /* TODO */ }
     private void ViewImage(string url) { /* TODO: Open image modal */ }
+
+    private string GetMapQuery()
+    {
+        return Uri.EscapeDataString($"{job.Address ?? string.Empty} {job.Suburb} {job.State} {job.PostCode}");
+    }
 
     private string GetStatusDisplay(JobStatus status) => status switch
     {

--- a/FindTradie.Web/wwwroot/css/job-details.css
+++ b/FindTradie.Web/wwwroot/css/job-details.css
@@ -393,6 +393,18 @@
     color: #64748b;
 }
 
+.map-preview {
+    height: 180px;
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.map-preview iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+
 .map-placeholder {
     height: 180px;
     background: #f1f5f9;

--- a/FindTradie.Web/wwwroot/css/user-job-details-quotes.css
+++ b/FindTradie.Web/wwwroot/css/user-job-details-quotes.css
@@ -339,6 +339,12 @@
     background: linear-gradient(135deg, #e0e7ff, #c7d2fe);
 }
 
+.map-container iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+
 .map-placeholder {
     height: 100%;
     display: flex;


### PR DESCRIPTION
## Summary
- embed Google Maps preview in job details location card
- show map preview on user job details page
- display removal `X` icon for photos on edit job page

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d1256194832ea3870032723154b3