### PR TITLE
Enable full-size image viewing on job details

### DIFF
--- a/FindTradie.Web/Pages/UserJobDetails.razor
+++ b/FindTradie.Web/Pages/UserJobDetails.razor
@@ -344,6 +344,17 @@
     </section>
 </div>
 
+<!-- Image Modal -->
+@if (showImageModal && !string.IsNullOrEmpty(selectedImageUrl))
+{
+    <div class="photo-modal" @onclick="CloseImageModal">
+        <div class="modal-content" @onclick:stopPropagation="true">
+            <button class="modal-close" @onclick="CloseImageModal">&times;</button>
+            <img src="@selectedImageUrl" alt="Job image" />
+        </div>
+    </div>
+}
+
 @code {
     [Parameter] public Guid JobId { get; set; }
 
@@ -402,7 +413,20 @@
     private void CallTradie() { /* TODO */ }
     private void MarkComplete() { /* TODO */ }
     private void CancelJob() { /* TODO */ }
-    private void ViewImage(string url) { /* TODO: Open image modal */ }
+    private bool showImageModal = false;
+    private string? selectedImageUrl;
+
+    private void ViewImage(string url)
+    {
+        selectedImageUrl = url;
+        showImageModal = true;
+    }
+
+    private void CloseImageModal()
+    {
+        showImageModal = false;
+        selectedImageUrl = null;
+    }
 
     private string GetMapQuery()
     {

--- a/FindTradie.Web/wwwroot/css/user-job-details-quotes.css
+++ b/FindTradie.Web/wwwroot/css/user-job-details-quotes.css
@@ -1388,7 +1388,44 @@
         font-size: 2rem;
     }
 
-    .stat-value {
-        font-size: 1.5rem;
-    }
+.stat-value {
+    font-size: 1.5rem;
+}
+}
+
+/* Image Modal Styles */
+.photo-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.photo-modal .modal-content {
+    position: relative;
+    max-width: 90%;
+    max-height: 90%;
+}
+
+.photo-modal .modal-content img {
+    max-width: 100%;
+    max-height: 100%;
+    border-radius: 8px;
+}
+
+.photo-modal .modal-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: none;
+    color: white;
+    font-size: 2rem;
+    cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- Allow clicking job images on user details page to open a full-size modal preview
- Style and script modal overlay for enlarged images

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d39163c8832ea8ac9d5b723e9936