### PR TITLE
style: improve photo modal close button

### DIFF
--- a/FindTradie.Web/Pages/UserJobDetails.razor
+++ b/FindTradie.Web/Pages/UserJobDetails.razor
@@ -348,8 +348,8 @@
 @if (showImageModal && !string.IsNullOrEmpty(selectedImageUrl))
 {
     <div class="photo-modal" @onclick="CloseImageModal">
+        <button class="modal-close" @onclick="CloseImageModal" aria-label="Close image"></button>
         <div class="modal-content" @onclick:stopPropagation="true">
-            <button class="modal-close" @onclick="CloseImageModal">&times;</button>
             <img src="@selectedImageUrl" alt="Job image" />
         </div>
     </div>

--- a/FindTradie.Web/wwwroot/css/user-job-details-quotes.css
+++ b/FindTradie.Web/wwwroot/css/user-job-details-quotes.css
@@ -1421,11 +1421,35 @@
 
 .photo-modal .modal-close {
     position: absolute;
-    top: 10px;
-    right: 10px;
-    background: none;
-    border: none;
-    color: white;
-    font-size: 2rem;
+    top: 20px;
+    right: 20px;
+    background: #000000;
+    border: 2px solid #ffffff;
+    color: #ffffff;
+    font-size: 24px;
+    font-weight: bold;
     cursor: pointer;
+    width: 45px;
+    height: 45px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s ease-in-out;
+    z-index: 1001;
+    line-height: 1;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+}
+
+.photo-modal .modal-close:hover {
+    background: #ff0000;
+    border-color: #ffffff;
+    transform: scale(1.1);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.7);
+}
+
+.photo-modal .modal-close::before {
+    content: "✕";
+    font-size: 26px;
+    font-weight: bold;
 }


### PR DESCRIPTION
## Summary
- Move photo modal close button outside the enlarged image
- Style modal close button as a circular X button positioned at top-right

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dac26700832eb70f27ea9310d4c3