### PR TITLE
fix: fit job detail image modal to screen

### DIFF
--- a/FindTradie.Web/wwwroot/css/job-details.css
+++ b/FindTradie.Web/wwwroot/css/job-details.css
@@ -417,6 +417,32 @@
 }
 
 
+/* Photo Modal */
+.photo-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.photo-modal .modal-content {
+    position: relative;
+    max-width: 90%;
+    max-height: 90%;
+}
+
+.photo-modal .modal-content img {
+    max-width: 100%;
+    max-height: 100%;
+    border-radius: 8px;
+}
+
 /* Photo Modal - Fixed Close Button */
 .photo-modal .modal-close {
     position: absolute;


### PR DESCRIPTION
## Summary
- ensure job detail image modal uses viewport-constrained sizing so enlarged photos fit on screen

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dcf813b4832e9e06b6dad33c5e9e