### PR TITLE
Implement cancel job and shared saving modal

### DIFF
--- a/FindTradie.Web/Pages/EditJob.razor
+++ b/FindTradie.Web/Pages/EditJob.razor
@@ -17,6 +17,7 @@
 <link rel="stylesheet" href="css/EditJob.css" />
 
 <div class="edit-job-container">
+    <SavingModal Show="@isSaving" />
     <!-- Header with Back Button -->
     <section class="page-header-compact">
         <div class="container">

--- a/FindTradie.Web/Pages/PostJob.razor
+++ b/FindTradie.Web/Pages/PostJob.razor
@@ -14,6 +14,7 @@
 <PageTitle>Post a Job - FindTradie</PageTitle>
 
 <div class="post-job-page">
+    <SavingModal Show="@isSaving" />
     <!-- Progress Bar -->
     <div class="progress-bar-container">
         <div class="container">
@@ -347,6 +348,7 @@
     private JobPostModel job = new();
     private List<PhotoModel> uploadedPhotos = new();
     private bool agreedToTerms = false;
+    private bool isSaving = false;
 
     private void NextStep()
     {
@@ -390,44 +392,52 @@
 
     private async Task PostJobAsync()
     {
-        var user = await AuthService.GetCurrentUserAsync();
-        if (user == null) return;
+        isSaving = true;
+        try
+        {
+            var user = await AuthService.GetCurrentUserAsync();
+            if (user == null) return;
 
-        // Map UI service string to enum (no dependency on ServiceCategory.Other)
-        var category = MapCategory(job.ServiceType);
+            // Map UI service string to enum (no dependency on ServiceCategory.Other)
+            var category = MapCategory(job.ServiceType);
 
-        var (budgetMin, budgetMax) = ParseBudget(job.BudgetRange);
+            var (budgetMin, budgetMax) = ParseBudget(job.BudgetRange);
 
-        var request = new CreateJobRequest(
-            Title: job.Title,
-            Description: job.Description,
-            Category: category,
-            SubCategory: job.ServiceType,      // keep original text, including "Other"
-            Urgency: JobUrgency.Normal,
-            BudgetMin: budgetMin,
-            BudgetMax: budgetMax,
-            PreferredStartDate: null,
-            PreferredEndDate: null,
-            IsFlexibleTiming: string.Equals(job.Timing, "flexible", StringComparison.OrdinalIgnoreCase),
-            CustomerId: user.Id,
-            CustomerName: $"{user.FirstName} {user.LastName}",
-            CustomerEmail: user.Email,
-            CustomerPhone: user.PhoneNumber,
-            Address: job.Address,
-            Suburb: job.Suburb,
-            State: job.State,
-            PostCode: job.Postcode,
-            Latitude: 0,
-            Longitude: 0,
-            SpecialRequirements: null,
-            RequiresLicense: false,
-            RequiresInsurance: false,
-            ImageUrls: uploadedPhotos.Select(p => p.Url).ToList()
-        );
+            var request = new CreateJobRequest(
+                Title: job.Title,
+                Description: job.Description,
+                Category: category,
+                SubCategory: job.ServiceType,      // keep original text, including "Other"
+                Urgency: JobUrgency.Normal,
+                BudgetMin: budgetMin,
+                BudgetMax: budgetMax,
+                PreferredStartDate: null,
+                PreferredEndDate: null,
+                IsFlexibleTiming: string.Equals(job.Timing, "flexible", StringComparison.OrdinalIgnoreCase),
+                CustomerId: user.Id,
+                CustomerName: $"{user.FirstName} {user.LastName}",
+                CustomerEmail: user.Email,
+                CustomerPhone: user.PhoneNumber,
+                Address: job.Address,
+                Suburb: job.Suburb,
+                State: job.State,
+                PostCode: job.Postcode,
+                Latitude: 0,
+                Longitude: 0,
+                SpecialRequirements: null,
+                RequiresLicense: false,
+                RequiresInsurance: false,
+                ImageUrls: uploadedPhotos.Select(p => p.Url).ToList()
+            );
 
-        var result = await JobService.CreateJobAsync(request);
-        if (result.Success && result.Data != null)
-            Navigation.NavigateTo($"/job-posted/{result.Data.Id}");
+            var result = await JobService.CreateJobAsync(request);
+            if (result.Success && result.Data != null)
+                Navigation.NavigateTo($"/job-posted/{result.Data.Id}");
+        }
+        finally
+        {
+            isSaving = false;
+        }
     }
 
     private static (decimal? min, decimal? max) ParseBudget(string range) => range switch

--- a/FindTradie.Web/Pages/SendQuote.razor
+++ b/FindTradie.Web/Pages/SendQuote.razor
@@ -7,6 +7,7 @@
 <PageTitle>Send Quote - FindTradie</PageTitle>
 <link rel="stylesheet" href="css/send-quote.css" />
 <div class="send-quote-page">
+    <SavingModal Show="@isSubmitting" Message="Submitting quote..." />
     <div class="container">
         <!-- Progress Indicator -->
         <div class="progress-indicator">

--- a/FindTradie.Web/Pages/UserJobDetails.razor
+++ b/FindTradie.Web/Pages/UserJobDetails.razor
@@ -344,6 +344,22 @@
     </section>
 </div>
 
+<!-- Cancel Job Modal -->
+@if (showCancelModal)
+{
+    <div class="cancel-modal" @onclick="CloseCancelModal">
+        <div class="modal-content" @onclick:stopPropagation="true">
+            <h3>Cancel Job</h3>
+            <p>Are you sure you want to cancel this job?</p>
+            <textarea class="form-control" placeholder="Reason (optional)" @bind="cancelReason"></textarea>
+            <div class="modal-actions">
+                <button class="btn btn-secondary" @onclick="CloseCancelModal">Keep Job</button>
+                <button class="btn btn-danger" @onclick="ConfirmCancelJob">Cancel Job</button>
+            </div>
+        </div>
+    </div>
+}
+
 <!-- Image Modal -->
 @if (showImageModal && !string.IsNullOrEmpty(selectedImageUrl))
 {
@@ -355,11 +371,16 @@
     </div>
 }
 
+<SavingModal Show="@isSaving" Message="Cancelling job..." />
+
 @code {
     [Parameter] public Guid JobId { get; set; }
 
     private JobDetailViewModel job = new();
     private bool isLoading = true;
+    private bool showCancelModal = false;
+    private bool isSaving = false;
+    private string cancelReason = string.Empty;
 
     protected override async Task OnInitializedAsync()
     {
@@ -412,7 +433,30 @@
     private void LeaveReview() => Navigation.NavigateTo($"/job/{JobId}/review");
     private void CallTradie() { /* TODO */ }
     private void MarkComplete() { /* TODO */ }
-    private void CancelJob() { /* TODO */ }
+    private void CancelJob() => showCancelModal = true;
+
+    private void CloseCancelModal()
+    {
+        showCancelModal = false;
+        cancelReason = string.Empty;
+    }
+
+    private async Task ConfirmCancelJob()
+    {
+        isSaving = true;
+        var response = await JobService.UpdateJobStatusAsync(JobId, JobStatus.Cancelled, cancelReason);
+        isSaving = false;
+        showCancelModal = false;
+
+        if (response.Success)
+        {
+            Navigation.NavigateTo("/my-jobs");
+        }
+        else
+        {
+            await JSRuntime.InvokeVoidAsync("alert", $"Failed to cancel job: {response.Message}");
+        }
+    }
     private bool showImageModal = false;
     private string? selectedImageUrl;
 

--- a/FindTradie.Web/Shared/SavingModal.razor
+++ b/FindTradie.Web/Shared/SavingModal.razor
@@ -1,0 +1,16 @@
+@if (Show)
+{
+    <div class="save-modal-overlay">
+        <div class="save-modal-content">
+            <div class="spinner-border text-primary" role="status">
+                <span class="visually-hidden">@Message</span>
+            </div>
+            <p>@Message</p>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public bool Show { get; set; }
+    [Parameter] public string Message { get; set; } = "Saving...";
+}

--- a/FindTradie.Web/wwwroot/css/site.css
+++ b/FindTradie.Web/wwwroot/css/site.css
@@ -2594,3 +2594,27 @@ h1, h2, h3, h4, h5, h6, p, span, div, label {
         margin-bottom: 8px;
     }
 }
+
+/* Save modal overlay */
+.save-modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+}
+
+.save-modal-content {
+    background: #ffffff;
+    padding: 2rem;
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+}

--- a/FindTradie.Web/wwwroot/css/user-job-details-quotes.css
+++ b/FindTradie.Web/wwwroot/css/user-job-details-quotes.css
@@ -1453,3 +1453,32 @@
     font-size: 26px;
     font-weight: bold;
 }
+
+/* Cancel job confirmation modal */
+.cancel-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.cancel-modal .modal-content {
+    background: #ffffff;
+    padding: 1.5rem;
+    border-radius: 8px;
+    width: 90%;
+    max-width: 400px;
+}
+
+.cancel-modal .modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- Add cancel job confirmation with optional reason and backend status update
- Introduce reusable saving modal component and apply across job-related forms
- Style cancel and saving modals for consistent UX

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6def0daec832ea0af60303cdec574