### PR TITLE
Show saving modal during save actions

### DIFF
--- a/FindTradie.Web/Pages/JobDetails.razor
+++ b/FindTradie.Web/Pages/JobDetails.razor
@@ -9,6 +9,7 @@
 <link rel="stylesheet" href="css/job-details.css" />
 
 <div class="job-details-page">
+    <SavingModal Show="@isSaving" Message="Saving job..." />
     @if (isLoading)
     {
         <div class="loading-container">
@@ -287,6 +288,7 @@
     private bool hasAlreadyQuoted = false;
     private bool showPhotoModal = false;
     private PhotoDto? selectedPhoto;
+    private bool isSaving = false;
 
     protected override async Task OnInitializedAsync()
     {
@@ -404,8 +406,16 @@
 
     private async Task SaveJob()
     {
-        // Implement save functionality
-        await Task.CompletedTask;
+        isSaving = true;
+        try
+        {
+            // Implement save functionality
+            await Task.CompletedTask;
+        }
+        finally
+        {
+            isSaving = false;
+        }
     }
 
     private async Task ShareJob()

--- a/FindTradie.Web/Pages/MyProfile.razor
+++ b/FindTradie.Web/Pages/MyProfile.razor
@@ -12,6 +12,7 @@
 <link rel="stylesheet" href="css/my-profile.css" />
 
 <div class="my-profile-page">
+    <SavingModal Show="@isSaving" />
     <!-- Page Header -->
     <div class="page-header">
         <div class="container">

--- a/FindTradie.Web/Pages/Settings.razor
+++ b/FindTradie.Web/Pages/Settings.razor
@@ -10,6 +10,7 @@
 <link rel="stylesheet" href="css/settings.css" />
 
 <div class="settings-page">
+    <SavingModal Show="@isSaving" />
     <!-- Page Header -->
     <div class="settings-header">
         <div class="container">


### PR DESCRIPTION
## Summary
- Display `SavingModal` overlay when saving profile updates
- Show saving modal while persisting settings changes
- Add saving overlay for saving jobs

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e910c534832eba3b54b30979c331